### PR TITLE
Use mysql full text search for search endpoint

### DIFF
--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -34,6 +34,8 @@ class DeckAddHandler(BaseHandler):
                 tag_id = connector.call_procedure('CREATE_TAG', tag)[0]['id']
                 connector.call_procedure('ADD_TAG_TO_DECK', tag_id, deck_id)
 
+            connector.call_procedure('SET_DELIMITED_TAGS', deck_id, ",".join(tags))
+
             # Create cards for the deck.
             for index in xrange(len(cards)):
                 if not isinstance(cards[index], dict):
@@ -139,6 +141,8 @@ class DeckUUIDHandler(BaseHandler):
                     tag_id = connector.call_procedure('CREATE_TAG', tag)[0]['id']
                     connector.call_procedure('ADD_TAG_TO_DECK', tag_id, uuid)
 
+                connector.call_procedure('SET_DELIMITED_TAGS', uuid, ",".join(tags))
+
             # Edit cards.
             if actions is not None:
                 for action in actions:
@@ -168,7 +172,6 @@ class DeckUUIDHandler(BaseHandler):
                             connector.call_procedure('UNFLAG_CARD', action['card_id'], user_id)
 
             # Increment both the deck version and the user data version.
-            # TODO set last_update and last_update_device.
             connector.call_procedure('INCREMENT_DECK_VERSION', user_id, uuid)
             connector.call_procedure('INCREMENT_USER_DATA_VERSION', user_id, uuid, device)
 
@@ -243,6 +246,8 @@ class DeckUUIDHandler(BaseHandler):
                     raise TypeError
                 tag_id = connector.call_procedure('CREATE_TAG', tag)[0]['id']
                 connector.call_procedure('ADD_TAG_TO_DECK', tag_id, uuid)
+
+            connector.call_procedure('SET_DELIMITED_TAGS', uuid, ",".join(tags))
 
             originalCards = connector.call_procedure('FETCH_CARDS', uuid)
 

--- a/Server/App/api/discover.py
+++ b/Server/App/api/discover.py
@@ -4,11 +4,11 @@ import logging
 from config import StatusCode
 from utils.serializer import serializer
 from utils.base_handler import BaseHandler
-from utils.wrappers import authorize_request_and_create_db_connector, require_query_string_params
+from utils.wrappers import authorize_request_and_create_db_connector, require_query_string_params, optional_query_string_params
 
 class TopHandler(BaseHandler):
     @authorize_request_and_create_db_connector
-    @require_query_string_params('page')
+    @optional_query_string_params('page')
     def get(self, page, connector):
         """Retrieve metadata for the most popular decks."""
 
@@ -26,7 +26,7 @@ class TopHandler(BaseHandler):
 
 class NewHandler(BaseHandler):
     @authorize_request_and_create_db_connector
-    @require_query_string_params('page')
+    @optional_query_string_params('page')
     def get(self, page, connector):
         """Retrieve metadata for newest decks."""
 
@@ -42,15 +42,12 @@ class NewHandler(BaseHandler):
 
 class SearchHandler(BaseHandler):
     @authorize_request_and_create_db_connector
-    @require_query_string_params('query', 'tags', 'page')
-    def get(self, query, tags_json, page, connector):
+    @require_query_string_params('query')
+    @optional_query_string_params('page')
+    def get(self, page, query, connector):
         """Retrieve metadata for decks matching the search string."""
 
-        tags = json.loads(tags_json)
-
-        tags_string = ",".join(tags)
-
-        decks = connector.call_procedure('SEARCH_DECKS', query, tags_string, len(tags), page)
+        decks = connector.call_procedure('SEARCH_DECKS', query, page)
 
         for deck in decks:
             deck['tags'] = map(lambda x: x['tag'], connector.call_procedure('GET_TAGS', deck["uuid"]))

--- a/Server/App/utils/wrappers.py
+++ b/Server/App/utils/wrappers.py
@@ -63,6 +63,24 @@ def require_query_string_params(*params):
         return wrapper
     return func_wrapper
 
+def optional_query_string_params(*params):
+    """Extract optional parameters from a query string."""
+
+    def func_wrapper(func):
+        def wrapper(*args, **kwargs):
+            self = args[0]
+            param_vals = []
+            for param in params:
+                if param in self.request.args:
+                    param_vals.append(self.request.args[param])
+                else:
+                    param_vals.append(None)
+                
+            # Call wrapped function with extracted parameters
+            return func(self, *(param_vals + list(args)[1:]), **kwargs)
+        return wrapper
+    return func_wrapper
+
 
 def require_params(*params):
     """Extract parameters from a request payload."""

--- a/Server/SQL/schema.sql
+++ b/Server/SQL/schema.sql
@@ -20,10 +20,11 @@ CREATE TABLE IF NOT EXISTS Deck
     owner VARCHAR(36) NOT NULL,
     rating INTEGER NOT NULL DEFAULT 0,
     public BOOLEAN NOT NULL DEFAULT FALSE,
-    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    tags_delimited VARCHAR(500),
+    deleted BOOLEAN NOT NULL DEFAULT FALSE, 
     version INTEGER NOT NULL DEFAULT 0,
     share_code VARCHAR(8) UNIQUE,
-
+    FULLTEXT(name, tags_delimited),
     FOREIGN KEY (owner) REFERENCES User(uuid)
 );
 

--- a/Spec/API.md
+++ b/Spec/API.md
@@ -364,11 +364,10 @@ Response:
 ### Search
 Request:
 ```
-GET /api/v1/discover/search?query=<query>&tags=<tags>[&page=<page>]
+GET /api/v1/discover/search?query=<query>[&page=<page>]
 ```
 Response description:
 - `query`: String used to search by deck name.
-- `tags`: Serialized array of tags to search by.
 - `page`: is the page offset into the result set (1 by default).
 
 Response:


### PR DESCRIPTION
Fixes #51 

@ClaytonPassmore 

Changed search procedure to take advantage of mysql's full text searching.

Decided to leave the Tags table in, even after adding the tags_delimited column since a delimited column is useless for any queries that isn't full text searching