### PR TITLE
refactor api classes to use common CueApi class

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -3,11 +3,11 @@ import type { PromiseAction } from './types';
 import type {Deck} from '../api/types';
 import LibraryApi from '../api/Library';
 
-async function loadLibrary(state): PromiseAction {
-  let library = await LibraryApi.fetchLibrary(state);
+async function loadLibrary(): PromiseAction {
+  let library = await LibraryApi.fetchLibrary();
   let decks = [];
   for (let deckMetadata of library) {
-  	let deck = await LibraryApi.fetchDeck(deckMetadata.uuid, state);
+  	let deck = await LibraryApi.fetchDeck(deckMetadata.uuid);
   	decks.push(deck);
   }
   return {

--- a/Cue/app/actions/login.js
+++ b/Cue/app/actions/login.js
@@ -4,8 +4,10 @@ import AuthenticationApi from '../api/Authentication';
 import FacebookApi from '../api/Facebook';
 import { LoginManager, AccessToken,  } from 'react-native-fbsdk';
 import { loadLibrary } from './library';
+import CueApi from '../api/CueApi';
 
 function logIn(cueUserId: string, cueAccessToken: string): Action {
+  CueApi.setAuthHeader(cueUserId, cueAccessToken);
   return {
     type: 'LOGGED_IN',
     data: {
@@ -16,6 +18,7 @@ function logIn(cueUserId: string, cueAccessToken: string): Action {
 }
 
 function logOut(): Action {
+  CueApi.setAuthHeader(null, null);
   return {
     type: 'LOGGED_OUT',
   };
@@ -38,7 +41,7 @@ function serverLogin(): ThunkAction {
     login.then(
       (result) => {
         dispatch(result[0]);
-        dispatch(loadLibrary(getState()));
+        dispatch(loadLibrary());
         FacebookApi.getName(data=>{dispatch(loadUsername(data.name))});
       }
     ).catch(

--- a/Cue/app/api/Authentication.js
+++ b/Cue/app/api/Authentication.js
@@ -1,35 +1,16 @@
 // @flow
-import { serverURL } from '../env';
+import CueApi from './CueApi';
 
 var AuthenticationApi = {
 	authenticate(userId: ?string, accessToken: ?string) {
-		let url = serverURL+'/api/v1/auth';
+		let url = '/api/v1/auth';
 		let method = 'POST'
 		let body = JSON.stringify({
 				user_id: userId,
 				access_token: accessToken,
 			})
-
-		return fetch(url, {
-			method: method,
-			body: body
-		})
-		.then(checkStatus)
-		.then(response => response.json())
-		.catch(e => {
-			throw (e)
-		});
+		return CueApi.fetch(url, method, body);
 	},
-}
-
-var checkStatus = function(response) {
-	if (response.status >= 200 && response.status < 300) {
-		return response;
-	} else {
-		let error = new Error(response.statusText);
-		error.response = response;
-		throw error;
-	}
 }
 
 module.exports = AuthenticationApi;

--- a/Cue/app/api/CueApi.js
+++ b/Cue/app/api/CueApi.js
@@ -1,0 +1,46 @@
+// @flow
+'use strict'
+
+import { serverURL } from '../env';
+
+class CueApi {
+	static userId  = null;
+	static accessToken = null;
+
+	static setAuthHeader(userId: ?string, accessToken: ?string) {
+		this.userId = userId;
+		this.accessToken = accessToken;
+	}
+
+	static fetch (endpoint: string, method: string = 'GET', body: ?string = null): Promise<JSON> {
+		let headers = null;
+		if (this.userId != null && this.accessToken != null) {
+			headers = {
+				'X-CUE-USER-ID' : this.userId,
+				'X-CUE-ACCESS-TOKEN': this.accessToken,
+			}
+		}
+		return fetch(serverURL + endpoint, {
+			method: method,
+			headers: headers,
+			body: body,
+		})
+		.then(checkStatus)
+		.then(response => response.json())
+		.catch(e => {
+			throw (e)
+		});
+	}
+}
+
+var checkStatus = function(response) {
+	if (response.ok) {
+		return response;
+	} else {
+		let error = new Error(response.statusText);
+		error.response = response;
+		throw error;
+	}
+}
+
+module.exports = CueApi;

--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -1,55 +1,19 @@
 // @flow
-import { serverURL } from '../env';
+import CueApi from './CueApi';
 
-
-//TODO: not sure proper way to get state in the api
-//TODO: look into moving checkStatus and auth header creation into common util
 var LibraryApi = {
 
-	fetchLibrary(state) {
-		let url = serverURL + '/api/v1/library';
-		let user = state.user;
-		console.info('Fetching Library from URL: ' + url)
-		return fetch(url, {
-			headers: {
-				'X-CUE-USER-ID' : user.userId,
-				'X-CUE-ACCESS-TOKEN': user.accessToken,
-			}
-		})
-		.then(checkStatus)
-		.then(response => response.json())
-		.catch(e => {
-			throw (e)
-		});
+	fetchLibrary() {
+		let endpoint = '/api/v1/library';
+		console.info('Fetching Library from endpoint: ' + endpoint)
+		return CueApi.fetch(endpoint);
 	},
 
-	fetchDeck(uuid : string, state) {
-		let url = serverURL + '/api/v1/deck/' + uuid;
-		let user = state.user;
-		console.info('Fetching deck "' + uuid + '" from URL: ' + url)
-		return fetch(url, {
-			headers: {
-				'X-CUE-USER-ID' : user.userId,
-				'X-CUE-ACCESS-TOKEN': user.accessToken,
-			}
-		})
-		.then(checkStatus)
-		.then(response => response.json())
-		.catch(e => {
-			throw (e)
-		});
+	fetchDeck(uuid : string) {
+		let endpoint = '/api/v1/deck/' + uuid;
+		console.info('Fetching deck "' + uuid + '" from endpoint: ' + endpoint)
+		return CueApi.fetch(endpoint);
 	},
-}
-
-var checkStatus = function(response) {
-	if (response.status >= 200 && response.status < 300) {
-		return response;
-	} else {
-		console.warn('Fetch failed due to bad status ' + response.status + '. Response: ', response)
-		let error = new Error(response.statusText);
-		error.response = response;
-		throw error;
-	}
 }
 
 module.exports = LibraryApi;

--- a/Cue/app/reducers/library.js
+++ b/Cue/app/reducers/library.js
@@ -4,7 +4,7 @@ import type {Action} from '../actions/types';
 import type {Deck} from '../api/types';
 
 export type State = {
-  decks: Array<Deck>;
+  decks: ?Array<Deck>;
 };
 
 const initialState: State = {

--- a/Cue/app/store/configureStore.js
+++ b/Cue/app/store/configureStore.js
@@ -4,6 +4,7 @@ import {applyMiddleware, createStore} from 'redux';
 import thunk from 'redux-thunk';
 import {persistStore, autoRehydrate} from 'redux-persist';
 import promise from './promise';
+import CueApi from '../api/CueApi';
 var reducers = require('../reducers');
 var createLogger = require('redux-logger');
 var {AsyncStorage} = require('react-native');
@@ -21,6 +22,7 @@ var createCueStore = applyMiddleware(thunk, promise, logger)(createStore);
 function configureStore(onComplete: ?() => void) {
   const store = autoRehydrate()(createCueStore)(reducers);
   persistStore(store, {storage: AsyncStorage, blacklist: ['tabs']}, onComplete);
+  CueApi.setAuthHeader(store.getState().user.userId, store.getState().user.accessToken);
   if (isDebuggingInChrome) {
     window.store = store;
   }


### PR DESCRIPTION
Refactored the api classes to use a common class called CueApi

The CueAPi has 1 static method `fetch(endpoint: string, method: string = 'GET', body = null)`

I stored the userId and token as a static property in the class. This static property is set during:
LOGGED_OUT action,
LOGGED_IN action,
State persistence (app start)

This should solve the problem of storing the auth header. I tried using the `connect` method but it wasn't working for me.

Not sure if this is react-native best practice, but it worked in the testing I did.