### PR TITLE
cueApi static header should now be set properly on app restarts

### DIFF
--- a/Cue/app/setup.js
+++ b/Cue/app/setup.js
@@ -4,6 +4,7 @@ var CueApp = require('./CueApp');
 var React = require('React');
 var { Provider } = require('react-redux');
 var configureStore = require('./store/configureStore');
+import CueApi from './api/CueApi'
 const FBSDK = require('react-native-fbsdk');
 
 
@@ -22,7 +23,11 @@ function setup(): ReactClass<{}> {
       super();
       this.state = {
         isLoading: true,
-        store: configureStore(() => this.setState({isLoading: false})),
+        store: configureStore(() => {
+          let user = this.state.store.getState().user
+          CueApi.setAuthHeader(user.userId, user.accessToken);
+          this.setState({isLoading: false})
+        }),
       };
     }
     render() {

--- a/Cue/app/store/configureStore.js
+++ b/Cue/app/store/configureStore.js
@@ -4,7 +4,6 @@ import {applyMiddleware, createStore} from 'redux';
 import thunk from 'redux-thunk';
 import {persistStore, autoRehydrate} from 'redux-persist';
 import promise from './promise';
-import CueApi from '../api/CueApi';
 var reducers = require('../reducers');
 var createLogger = require('redux-logger');
 var {AsyncStorage} = require('react-native');
@@ -22,7 +21,6 @@ var createCueStore = applyMiddleware(thunk, promise, logger)(createStore);
 function configureStore(onComplete: ?() => void) {
   const store = autoRehydrate()(createCueStore)(reducers);
   persistStore(store, {storage: AsyncStorage, blacklist: ['tabs']}, onComplete);
-  CueApi.setAuthHeader(store.getState().user.userId, store.getState().user.accessToken);
   if (isDebuggingInChrome) {
     window.store = store;
   }


### PR DESCRIPTION
Should fix bug for `CueApi` static auth properties not being set properly on app restarts.

This bug happened because I was trying to set the `CueApi` headers directly after `persistStore()`, which happens async. This caused the `CueApi` headers to be set with `null` before the actual store was loaded from `persistStore(...)`