### PR TITLE
refresh library view when decks state changes

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -5,11 +5,12 @@ import LibraryApi from '../api/Library';
 
 async function loadLibrary(): PromiseAction {
   let library = await LibraryApi.fetchLibrary();
-  let decks = [];
+  let promises : Array<Promise<Deck>> = []
+
   for (let deckMetadata of library) {
-  	let deck = await LibraryApi.fetchDeck(deckMetadata.uuid);
-  	decks.push(deck);
+  	promises.push(LibraryApi.fetchDeck(deckMetadata.uuid));
   }
+  let decks = await Promise.all(promises);
   return {
     type: 'LOADED_LIBRARY',
     decks,

--- a/Cue/app/tabs/library/LibraryListView.js
+++ b/Cue/app/tabs/library/LibraryListView.js
@@ -60,7 +60,7 @@ class LibraryListView extends React.Component {
       data[section].push(deck)
     }
 
-    this.props.decks.forEach((deck) => {
+    decks.forEach((deck) => {
       if (deck.owner === this.props.userId) {
         addToData(SECTION_PRIVATE, deck)
       } else if (!deck.public && deck.share_code) {
@@ -83,19 +83,29 @@ class LibraryListView extends React.Component {
     return { data, headers }
   }
 
-  constructor(props: Props) {
-    super(props)
-
+  _getDataSource (decks: Array<Deck>) {
     let ds = new ListView.DataSource({
       rowHasChanged: (r1, r2) => r1 !== r2,
       sectionHeaderHasChanged: (s1, s2) => s1 !== s2
     })
+    let { data, headers } = this._categorizeDecks(decks)
+    return ds.cloneWithRowsAndSections(data, headers)
+  }
 
-    let { data, headers } = this._categorizeDecks(this.props.decks)
+  constructor(props: Props) {
+    super(props)
     this.state = {
-      dataSource: ds.cloneWithRowsAndSections(data, headers),
+      dataSource: this._getDataSource(props.decks),
       deviceOrientation: 'UNKNOWN'
     }
+  }
+
+
+  componentWillReceiveProps(newProps: Props) {
+    this.setState({
+      ...this.state,
+      dataSource: this._getDataSource(newProps.decks)
+    })
   }
 
   render() {


### PR DESCRIPTION
Refreshes the `LibraryListView` datasource whenever new props are passed in.

Also made a change to retrieve all deck's cards async so the loading will be faster.

This closes issue #46 


Right now there is currently no indication in the library view that the library is being loaded. It just says the library has no decks. I think while it is being loaded, a loading spinner could be displayed instead of the empty library view