### PR TITLE
Add support for actually flagging decks in Play Deck View

### DIFF
--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -34,7 +34,7 @@ var LibraryApi = {
   },
 
   editDeck (change){
-    let endpoint = 'api/v1/deck/' + change.uuid
+    let endpoint = '/api/v1/deck/' + change.uuid
     let body = JSON.stringify({
       device: DeviceInfo.getDeviceName(),
       parent_deck_version: change.parent_deck_version,

--- a/Cue/app/reducers/library.js
+++ b/Cue/app/reducers/library.js
@@ -44,9 +44,12 @@ function library(state: State = initialState, action: Action): State {
     }
 
   } else if (action.type === 'DECK_EDITED') {
+    console.info('Processing DECK_EDITED action', action)
     let change = action.change
+    console.info('Change: ', change)
     //update decks
     let deckIndex = decks.findIndex(deck => deck.uuid == change.uuid)
+    console.info('deckIndex: ', deckIndex)
     if (decks[deckIndex]) {
       decks[deckIndex] = {
         ...decks[deckIndex],
@@ -65,7 +68,7 @@ function library(state: State = initialState, action: Action): State {
         action: localChanges[changeIndex].action,
       }
     } else {
-      if (decks[deckIndex])
+      if (!decks[deckIndex])
         console.error("Could not find existing deck for edit action", change)
       else
         localChanges.push({
@@ -97,6 +100,7 @@ function library(state: State = initialState, action: Action): State {
 
 //merges card changes for a deck's cards
 function _mergeCardChanges(cards, changes) {
+  console.info('Merging card changes', cards, changes)
   if (! cards && !changes) return []
   if (!cards) return []
   if (!changes) return cards

--- a/Cue/app/reducers/library.js
+++ b/Cue/app/reducers/library.js
@@ -44,12 +44,9 @@ function library(state: State = initialState, action: Action): State {
     }
 
   } else if (action.type === 'DECK_EDITED') {
-    console.info('Processing DECK_EDITED action', action)
     let change = action.change
-    console.info('Change: ', change)
     //update decks
     let deckIndex = decks.findIndex(deck => deck.uuid == change.uuid)
-    console.info('deckIndex: ', deckIndex)
     if (decks[deckIndex]) {
       decks[deckIndex] = {
         ...decks[deckIndex],

--- a/Cue/app/tabs/library/play/FloatingCard.js
+++ b/Cue/app/tabs/library/play/FloatingCard.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { View, Text, Dimensions, Platform } from 'react-native'
+import { View, Image, Text, Dimensions, Platform } from 'react-native'
 import FlipCard from 'react-native-flip-card'
 
 import type { Card } from '../../../api/types'
@@ -45,6 +45,12 @@ const styles = {
     left: 0,
     right: 0,
   },
+  flag: {
+    tintColor: CueColors.flagIndicatorTint,
+    position: 'absolute',
+    top: 12,
+    right: 12,
+  },
   cardTextContainer: {
     flex: 1,
     padding: 16,
@@ -68,7 +74,8 @@ class CardFace extends React.Component {
     text: string,
     side: 'front' | 'back',
     position: number,
-    count: number
+    count: number,
+    flagged: boolean,
   }
 
   render() {
@@ -78,11 +85,14 @@ class CardFace extends React.Component {
 
     let extraTextStyle = this.props.side === 'front' ? styles.frontText : styles.backText
 
+    let flag = this.props.flagged ? <Image style={styles.flag} source={CueIcons.indicatorFlag} /> : undefined
+
     return (
       <View style={[styles.cardFace, extraCardFaceStyle]}>
         <Text style={styles.cardCount}>
           {this.props.position} of {this.props.count}
         </Text>
+        {flag}
         <View style={styles.cardTextContainer}>
           <Text style={[styles.text, extraTextStyle]}>
             {this.props.text}
@@ -115,14 +125,16 @@ export default class FloatingCard extends React.PureComponent {
             text={this.props.card.front}
             side={'front'}
             position={this.props.position}
-            count={this.props.count} />
+            count={this.props.count}
+            flagged={this.props.card.needs_review} />
 
           {/* Back Face */}
           <CardFace
             text={this.props.card.back}
             side={'back'}
             position={this.props.position}
-            count={this.props.count} />
+            count={this.props.count}
+            flagged={this.props.card.needs_review} />
         </FlipCard>
       </View>
     )

--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -3,6 +3,9 @@
 import React from 'react'
 import { Navigator, Animated, Easing, View, Text, Image, TouchableOpacity, PanResponder, Platform, Dimensions, StatusBar } from 'react-native'
 
+import { connect } from 'react-redux'
+import { editDeck } from '../../../actions'
+
 import type { Deck, Card } from '../../../api/types'
 
 import CueColors from '../../../common/CueColors'
@@ -67,11 +70,14 @@ type Props = {
   deck: Deck,
   shuffle?: boolean,
   startIndex?: number,
+
+  // From Redux:
+  flagCard: (deckUuid: string, cardUuid: string, flag: boolean) => any
 }
 
 type TriggeredAction = 'next' | 'flag' | 'back' | 'none'
 
-export default class PlayDeckView extends React.Component {
+class PlayDeckView extends React.Component {
   props: Props
 
   state: {
@@ -247,7 +253,8 @@ export default class PlayDeckView extends React.Component {
   }
 
   _commitFlagAction = () => {
-    // TODO Dispatch a Redux action?
+    let card = this.state.cards[this.state.index]
+    this.props.flagCard(this.props.deck.uuid, card.uuid, !card.needs_review)
 
     this._setCurrentCard(this.state.index + 1)
   }
@@ -485,3 +492,23 @@ export default class PlayDeckView extends React.Component {
       </View>)
   }
 }
+
+function actions(dispatch) {
+  return {
+    flagCard: (deckUuid: string, cardUuid: string, flag: boolean) => {
+      let change = {
+        uuid: deckUuid,
+        cards: [
+          {
+            action: 'edit',
+            uuid: cardUuid,
+            needs_review: flag,
+          }
+        ]
+      }
+      return dispatch(editDeck(change))
+    }
+  }
+}
+
+module.exports = connect(undefined, actions)(PlayDeckView)

--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -103,7 +103,8 @@ class PlayDeckView extends React.Component {
   constructor(props: Props) {
     super(props)
 
-    let cards = this.props.deck.cards || []
+    // Take a snapshot of the Deck in props
+    let cards = (this.props.deck.cards || []).slice(0)
     cards = this.props.shuffle ? this._shuffled(cards) : cards
 
     this.state = {
@@ -253,8 +254,12 @@ class PlayDeckView extends React.Component {
   }
 
   _commitFlagAction = () => {
+    // Update the local snapshot of the deck state
     let card = this.state.cards[this.state.index]
-    this.props.flagCard(this.props.deck.uuid, card.uuid, !card.needs_review)
+    card.needs_review = !card.needs_review
+
+    // Flag the card in the Redux store
+    this.props.flagCard(this.props.deck.uuid, card.uuid, card.needs_review)
 
     this._setCurrentCard(this.state.index + 1)
   }


### PR DESCRIPTION
The big 1-0-0! Closes #96. 😀

## Summary
`PlayDeckView` now takes a snapshot of the state of the deck when it is presented. Since it is not connected to any component which is actively receiving updates from Redux, `PlayDeckView` will dispatch `editDeck` actions while simultaneously updating its local snapshot.

## Issues
Since we call `setState` before the indicators disappear, the indicators can briefly display the state intended for the next card. You can see this at the end of the GIF below when the `REMOVE FLAG` indicator briefly turns into a `FLAG FOR REVIEW` indicator before disappearing. Not sure if it's a high priority to fix.

## GIF
![flag](https://cloud.githubusercontent.com/assets/13400887/24018536/b1e0c360-0a6a-11e7-8ca5-dfe9470ae6a5.gif)
