### PR TITLE
Fix filtering for cards which need review

### DIFF
--- a/Cue/app/tabs/library/CardListView.js
+++ b/Cue/app/tabs/library/CardListView.js
@@ -45,7 +45,7 @@ export default class CardListView extends React.Component {
     cards = cards || []
 
     let rows = isFiltering
-      ? cards.filter((card: Card) => { card.needs_review })
+      ? cards.filter((card: Card) => card.needs_review )
       : cards
 
     return ds.cloneWithRows(rows)


### PR DESCRIPTION
The function passed into `cards.filter` did not actually return any value, so the filtered list would always be empty.