### PR TITLE
Misc. Server Fixes

### DIFF
--- a/Server/App/model/deck.py
+++ b/Server/App/model/deck.py
@@ -51,9 +51,12 @@ class Deck(object):
         self.connector.query_transactionally(
             'UPDATE Deck SET public=%s WHERE uuid=%s', public, self.uuid)
 
+    def nullify_share_code(self):
+        self.connector.call_procedure_transactionally('SET_SHARE_CODE', self.uuid, None)
+
     def set_tags(self, tags):
         self.connector.call_procedure_transactionally(
-            'SET_DELIMITED_TAGS', self.uuid, ','.join(tags))
+            'SET_DELIMITED_TAGS', self.uuid, ','.join(tags) if len(tags) > 0 else None)
 
     def update_deck_version(self):
         self.connector.call_procedure_transactionally('INCREMENT_DECK_VERSION', self.uuid)
@@ -120,8 +123,8 @@ class Deck(object):
 
     def metadata_to_json(self, user_id):
         deck = self.get_metadata(user_id)
-        return json.dumps(deck, default=serializer)
+        return json.dumps(deck, default=serializer, ensure_ascii=False)
 
     def full_deck_to_json(self, user_id):
         deck = self.get_full_deck(user_id)
-        return json.dumps(deck, default=serializer)
+        return json.dumps(deck, default=serializer, ensure_ascii=False)

--- a/Server/App/model/user.py
+++ b/Server/App/model/user.py
@@ -32,7 +32,7 @@ class User(object):
         return result[0]
 
     def to_json(self):
-        return json.dumps(self.get())
+        return json.dumps(self.get(), ensure_ascii=False)
 
     def set_name(self, name):
         self.connector.call_procedure_transactionally('SET_USER_NAME', self.uuid, name)

--- a/Server/App/utils/base_handler.py
+++ b/Server/App/utils/base_handler.py
@@ -6,16 +6,16 @@ from config import StatusCode
 class BaseHandler(object):
     request = flask.request
 
-    def post(self):
+    def post(self, *args, **kwargs):
         self.abort(StatusCode.NOT_FOUND)
 
-    def get(self):
+    def get(self, *args, **kwargs):
         self.abort(StatusCode.NOT_FOUND)
 
-    def put(self):
+    def put(self, *args, **kwargs):
         self.abort(StatusCode.NOT_FOUND)
 
-    def delete(self):
+    def delete(self, *args, **kwargs):
         self.abort(StatusCode.NOT_FOUND)
 
     def render_template(self, *args):

--- a/Server/SQL/procedures.sql
+++ b/Server/SQL/procedures.sql
@@ -262,6 +262,7 @@ BEGIN
         Deck.name,
         Deck.rating,
         (SELECT COUNT(*) FROM Rating WHERE deck_id=did) AS num_ratings,
+        (SELECT COUNT(*) FROM Card WHERE deck_id=did) AS num_cards,
         Deck.owner,
         Deck.public,
         Deck.version AS deck_version,

--- a/Spec/API.md
+++ b/Spec/API.md
@@ -110,6 +110,7 @@ PUT /api/v1/deck/<uuid>
     "parent_user_data_version" "<parent-user-data-version>",
     "name": "<name>",
     "public": true | false,
+    "unshare": true,
     "tags": ["<tag1>", "<tag2>", ...],
     "actions": [
         {
@@ -127,6 +128,7 @@ Request description:
 - `parent_user_data_version` (required): the current version of the user data for the deck
 - `name`: the name that the deck will be changed to
 - `public`: determines whether or not the deck should be discoverable by other users
+- `unshare`: nullifies the deck's share code if it exists
 - `tags`: the new list of strings that describe the deck
 - `actions`: a list of actions (add, edit, delete) as described below
 
@@ -181,7 +183,8 @@ POST /api/v1/deck/<uuid>
             "uuid": "<uuid>" | null,
             "front": "<Q>",
             "back": "<A>",
-            "position": "<P>"
+            "position": "<P>",
+            "needs_review": true | false
         },
         ...
     ]
@@ -197,6 +200,7 @@ Request description:
     - `front`: the text on the front of the card
     - `back`: the text on the back of the card
     - `position`: position of the card in the deck
+    - `needs_review` (optional): indicates if the user wants to mark the card as needs review
 
 Response: [Standard Full Deck Response](#full-response)
 
@@ -415,6 +419,7 @@ This response only contains metadata (does not include the cards in the deck).
     "name": "<name>",
     "rating": <rating>,
     "num_ratings": "<num-ratings>",
+    "num_cards": <num-cards>,
     "tags": ["<tag1>", "<tag2>", ...],
     "owner": "<userid>",
     "author": "<author>" | null,
@@ -435,6 +440,7 @@ Response description:
 - `name`: the name of the deck
 - `rating`: the deck rating (integer representing total net likes)
 - `num_ratings`: the number of ratings this deck has
+- `num_cards`: the number of cards in the deck
 - `tags`: a list of strings describing the contents of the deck
 - `owner`: the user id of the owner of the deck
 - `author`: the name of the owner of the deck (or null if not set)


### PR DESCRIPTION
- Added `unshare` option to edit deck endpoint
- Allow unicode content in JSON
- Allow default handler methods from `BaseHandler` class to take any parameters (e.g. uuid='adsf')
- Allow tags to be set to `null`
- Fix bug where new cards could not be flagged
- Return number of cards in standard metadata deck response
- Allow cards to be marked for review with the overwrite endpoint

Closes #95
Closes #107
Closes #110
Closes #111
Closes #114
Closes #118