### PR TITLE
Add accessible to metadata response

### DIFF
--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -45,8 +45,7 @@ class DeckUUIDHandler(BaseHandler):
     @optional_query_string_params('share_code')
     def get(self, share_code, user_id, connector, uuid):
         """Retrieve a full deck via its UUID."""
-        deck = (DeckPolicy.can_view(uuid, user_id, share_code, connector=connector) or
-                DeckPolicy.in_library(uuid, user_id, connector=connector))
+        deck = DeckPolicy.can_view(uuid, user_id, share_code, connector=connector)
         if deck is None:
             return self.make_response(status=StatusCode.NOT_FOUND)
 
@@ -257,8 +256,7 @@ class DeckRateHandler(BaseHandler):
     def post(self, rating, user_id, connector, uuid):
         """Rate existing decks."""
 
-        deck = (DeckPolicy.can_view(uuid, user_id, connector=connector) or
-                DeckPolicy.in_library(uuid, user_id, connector=connector))
+        deck = DeckPolicy.can_view(uuid, user_id, connector=connector)
         if deck is None:
             return self.make_response(status=StatusCode.NOT_FOUND)
 

--- a/Server/App/api/library.py
+++ b/Server/App/api/library.py
@@ -44,8 +44,7 @@ class LibraryCopyHandler(BaseHandler):
     def post(self, user_id, uuid, device, connector):
         """Copy a remote deck into a user's library."""
 
-        deck = (DeckPolicy.can_view(uuid, user_id, connector=connector) or
-                DeckPolicy.in_library(uuid, user_id, connector=connector))
+        deck = DeckPolicy.can_view(uuid, user_id, connector=connector)
         if deck is None:
             return self.make_response(status=StatusCode.NOT_FOUND)
 

--- a/Server/App/model/deck.py
+++ b/Server/App/model/deck.py
@@ -105,6 +105,7 @@ class Deck(object):
         if len(results) != 1:
             return None
         deck = results[0]
+        deck['accessible'] = self._is_accessible(deck, user_id)
 
         results = self.connector.call_procedure('GET_DELIMITED_TAGS', self.uuid)
         if len(results) != 1:
@@ -113,6 +114,15 @@ class Deck(object):
 
         deck['tags'] = [] if tags is None else tags.split(',')
         return deck
+
+    def _is_accessible(self, deck, user_id):
+        if deck['accession'] == 'private':
+            return True if user_id == deck['owner'] else False
+        if deck['accession'] == 'shared':
+            return True if (deck['public'] or deck['share_code'] is not None) else False
+        if deck['accession'] == 'public':
+            return True if deck['public'] else False
+        return False
 
     def get_full_deck(self, user_id):
         deck = self.get_metadata(user_id)

--- a/Server/App/policy/deck.py
+++ b/Server/App/policy/deck.py
@@ -11,8 +11,8 @@ class DeckPolicy(object):
             return None
 
         if (
+            not metadata['accessible'] and
             not metadata['public'] and
-            (user_id is None or metadata['owner'] != user_id) and
             (share_code is None or metadata['share_code'] != share_code)
         ):
             return None

--- a/Spec/API.md
+++ b/Spec/API.md
@@ -431,7 +431,8 @@ This response only contains metadata (does not include the cards in the deck).
     "last_update_device": "<last-update-device>" | null,
     "share_code": "<share-code>" | null,
     "deleted": true | false,
-    "accession": "public" | "private" | "shared" | null
+    "accession": "public" | "private" | "shared" | null,
+    "accessible": true | false
 }
 ```
 
@@ -453,6 +454,7 @@ Response description:
 - `share_code`: the code that can be entered by users to gain access to a remote private deck (null if a code has not been requested yet)
 - `deleted`: boolean indicating whether or not a deck has been deleted by the owner
 - `accession`: string indicating how the deck became part of the user's library (null if the deck is not a part of the user's library)
+- `accessible`: boolean indicating whether or not a deck is still retrievable given its current state and the user's accession
 
 *Note*: if the `deleted` flag is set to true in the response, the client should not expect to receive any other metadata about the deck (with the exception of `name` and `uuid`).
 


### PR DESCRIPTION
- `accessible` is a flag that indicates whether or not the user can still retrieve the given deck.

Closes #117.

**The bad news:** there is a bug right now so if a user had a shared deck, made it private, then made it shared again, users that added the deck the first time around via share code could potentially still have access to the deck because we don't save which share code you used to gain access to the deck.