### PR TITLE
Add extra bottom padding to LibraryListView on Android to avoid crashing into FAB

### DIFF
--- a/Cue/app/tabs/library/LibraryListView.js
+++ b/Cue/app/tabs/library/LibraryListView.js
@@ -21,6 +21,9 @@ const styles = {
     flexWrap: 'wrap',
     alignItems: 'flex-start',
     paddingHorizontal: 16,
+
+    // FAB height (56) + FAB padding (16) - to avoid crashing into FAB
+    paddingBottom: Platform.OS === 'android' ? 72 : undefined,
   },
   cardContainer: {
     marginBottom: 16,


### PR DESCRIPTION
Pretty self-explanatory.

Note that unlike in CardListView, we only need to account for the FAB's 16 pt of vertical padding once since the card containers already have 16 pt of bottom padding.

<img width="487" alt="screen shot 2017-03-19 at 2 37 02 am" src="https://cloud.githubusercontent.com/assets/13400887/24078768/017d5ee0-0c4d-11e7-8bf6-de6878db3397.png">
