### PR TITLE
Prevent empty decks from being played

### DIFF
--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -3,7 +3,7 @@
 'use strict';
 
 import React from 'react'
-import { View, Text, Image, ScrollView, ListView, Navigator, Platform } from 'react-native'
+import { View, Text, Image, ScrollView, ListView, Navigator, Platform, Alert } from 'react-native'
 
 import { connect } from 'react-redux'
 import { editDeck } from '../../actions'
@@ -108,6 +108,20 @@ class DeckView extends React.Component {
     }
   }
 
+  _onPlayDeck = () => {
+    if (!this.state.deck.cards || this.state.deck.cards.length === 0) {
+      Alert.alert(
+        (Platform.OS === 'android'
+          ? 'This deck is empty'
+          : 'This Deck is Empty'),
+        'To play this deck, add a few cards to it first.',
+        [{text: 'OK', style: 'cancel'}]
+      )
+    } else {
+      this.props.navigator.push({ playDeckSetup: this.state.deck })
+    }
+  }
+
   _getAllCommonItems = () => {
     return {
       addItem: {
@@ -193,9 +207,7 @@ class DeckView extends React.Component {
       const PrimaryFAB = MKButton.coloredFab()
         .withBackgroundColor(CueColors.primaryTint)
         .withStyle(styles.fab)
-        .withOnPress(() => {
-          this.props.navigator.push({ playDeckSetup: this.state.deck })
-        })
+        .withOnPress(() => { this._onPlayDeck() })
         .build()
 
       return (
@@ -215,7 +227,7 @@ class DeckView extends React.Component {
     if (Platform.OS !== 'android') {
       let playItem = {
         icon: CueIcons.play,
-        onPress: () => {this.props.navigator.push({playDeckSetup: this.state.deck})}
+        onPress: () => { this._onPlayDeck() }
       }
 
       return (


### PR DESCRIPTION
Closes #99.

Display an alert instead of allowing an empty deck to be played.

<img width="751" alt="screen shot 2017-03-19 at 3 11 15 am" src="https://cloud.githubusercontent.com/assets/13400887/24078943/14253464-0c52-11e7-88e0-0d6de16fe392.png">