### PR TITLE
Fix creating share codes when the deck isn't public

### DIFF
--- a/Cue/app/tabs/library/DeckSharingOptions.js
+++ b/Cue/app/tabs/library/DeckSharingOptions.js
@@ -150,6 +150,8 @@ class DeckSharingOptions extends React.Component {
           }
         ]
       )
+    } else {
+      this._doHandleSharedSubmit()
     }
   }
 


### PR DESCRIPTION
`_handleSharedSubmit` didn't call `_doHandleSharedSubmit` if the deck had non-`public` accession.