### PR TITLE
Adjust margins and padding in TextEntryTableRow

### DIFF
--- a/Cue/app/common/TextEntryTableRow.js
+++ b/Cue/app/common/TextEntryTableRow.js
@@ -97,7 +97,8 @@ export default class TextEntryTableRow extends React.Component {
   render() {
     let tableRowExtraStyle = {
       flexDirection: 'column',
-      paddingVertical: Platform.OS === 'android' ? 0 : undefined,
+      paddingVertical: Platform.OS === 'android' ? 0 : 12,
+      marginTop: Platform.OS === 'android' ? 8 : 0,
       minHeight: Platform.OS === 'android' ? 0 : undefined,
     }
     return (


### PR DESCRIPTION
Fixes #132 and gives Android a bit more breathing space.

Before:
<img width="757" alt="screen shot 2017-03-21 at 1 33 42 pm" src="https://cloud.githubusercontent.com/assets/13400887/24161648/6d63a62e-0e3b-11e7-85c3-555702149b0c.png">

After:
<img width="755" alt="screen shot 2017-03-21 at 1 35 36 pm" src="https://cloud.githubusercontent.com/assets/13400887/24161649/6d6e8684-0e3b-11e7-86db-f92d64197c11.png">