### PR TITLE
Fix loadLibrary bugs

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -85,7 +85,6 @@ function syncLibrary(localChanges): ThunkAction {
     })
     return Promise.all(promises).then(() => {
       console.info('failed syncs:  ', failedSyncs)
-      if (failedSyncs.length == 0) dispatch(loadLibrary())
       return failedSyncs;
     })
   };

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -73,12 +73,6 @@ class LibraryHome extends React.Component {
     }
   }
 
-  componentWillReceiveProps(newProps: Props) {
-    this.setState({
-      refreshing: false
-    })
-  }
-
   _refresh = () => {
     this.setState({refreshing: true})
     this.props.onSyncLibrary(this.props.localChanges).then(failedSyncs =>{
@@ -86,7 +80,9 @@ class LibraryHome extends React.Component {
         this.setState({refreshing: false})
         this.props.navigator.push({failedSyncs})
       } else {
-        this.props.onLoadLibrary()
+        this.props.onLoadLibrary().then(response => {
+          this.setState({refreshing: false})
+        })
       }
     })
     .catch(e => {
@@ -238,6 +234,7 @@ class LibraryHome extends React.Component {
         <CueHeader
           leftItem={leftItem}
           title='Library'
+          key={this.state.editing}
           rightItems={rightItems} />
         <LibraryListView
           style={styles.bodyContainer}

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -83,17 +83,15 @@ class LibraryHome extends React.Component {
     this.setState({refreshing: true})
     this.props.onSyncLibrary(this.props.localChanges).then(failedSyncs =>{
       if (failedSyncs && failedSyncs.length) {
-        this.props.navigator.push({failedSyncs})
         this.setState({refreshing: false})
+        this.props.navigator.push({failedSyncs})
       } else {
-        this.props.onLoadLibrary().then(response => {
-          this.setState({refreshing: false})
-        })
+        this.props.onLoadLibrary()
       }
     })
     .catch(e => {
-      console.warn('Failed to sync changes', e)
       this.setState({refreshing: false})
+      console.warn('Failed to sync changes', e)
       Alert.alert(
         (Platform.OS === 'android' ? 'Cue cloud sync failed' : 'Cue Cloud Sync Failed'),
         'Check your Internet connection and try again.'

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -80,21 +80,20 @@ class LibraryHome extends React.Component {
   }
 
   _refresh = () => {
+    this.setState({refreshing: true})
     this.props.onSyncLibrary(this.props.localChanges).then(failedSyncs =>{
       if (failedSyncs && failedSyncs.length) {
         this.props.navigator.push({failedSyncs})
+        this.setState({refreshing: false})
+      } else {
+        this.props.onLoadLibrary().then(response => {
+          this.setState({refreshing: false})
+        })
       }
-      this.setState({
-        refreshing: false,
-        editing: false
-      });
     })
     .catch(e => {
       console.warn('Failed to sync changes', e)
-      this.setState({
-        refreshing: false,
-        editing: false
-      });
+      this.setState({refreshing: false})
       Alert.alert(
         (Platform.OS === 'android' ? 'Cue cloud sync failed' : 'Cue Cloud Sync Failed'),
         'Check your Internet connection and try again.'


### PR DESCRIPTION
Fix 2 bugs

- don't `loadLibrary` on logout

- update refresh spinner only when `loadLibrary` is done

- edit button not showing up after syncing changes