### PR TITLE
Use TouchableHighlight instead of TouchableOpacity for DeckThumbnail

### DIFF
--- a/Cue/app/common/DeckThumbnail.js
+++ b/Cue/app/common/DeckThumbnail.js
@@ -3,7 +3,7 @@
 'use strict';
 
 import React from 'react'
-import { View, Image, Text, TouchableOpacity, TouchableNativeFeedback, Dimensions, Navigator, Platform } from 'react-native'
+import { View, Image, Text, TouchableHighlight, TouchableNativeFeedback, Dimensions, Navigator, Platform } from 'react-native'
 
 import type { Deck } from '../api/types'
 
@@ -11,6 +11,11 @@ import CueColors from './CueColors'
 import CueIcons from './CueIcons'
 
 const baseStyles = {
+  touchableHighlight: {
+    // Match the border radius on itemContainer to stop the highlight's
+    // underlay colour from leaking through the rounded corners
+    borderRadius: 2,
+  },
   itemContainer: {
     alignItems: 'flex-start',
     justifyContent: 'center',
@@ -172,9 +177,11 @@ export default class DeckThumbnail extends React.Component {
         )
       } else {
         return (
-          <TouchableOpacity onPress={this.props.onPress} >
+          <TouchableHighlight
+            style={styles.touchableHighlight}
+            onPress={this.props.onPress}>
             {content}
-          </TouchableOpacity>
+          </TouchableHighlight>
         )
       }
     } else {


### PR DESCRIPTION
The deck thumbnail always looked kind of off on iOS on touch down for some reason, this makes it feel much better.

iOS only. Android uses `TouchableNativeFeedback` so it is unaffected.

Before:
<img width="375" alt="opacity" src="https://cloud.githubusercontent.com/assets/13400887/24281442/fb2034b0-102e-11e7-9627-f931b6aa3ddd.png">

After:
<img width="375" alt="highlight" src="https://cloud.githubusercontent.com/assets/13400887/24281444/feebc26c-102e-11e7-9f7f-e69f65d6b8ce.png">
