### PR TITLE
Look up deck via share code

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -135,9 +135,9 @@ async function syncDeck(change) : PromiseAction {
   }
 }
 
-async function addLibrary(uuid: string): PromiseAction {
+async function addLibrary(uuid: string, shareCode?: string): PromiseAction {
   try {
-    await LibraryApi.addDeckToLibrary(uuid);
+    await LibraryApi.addDeckToLibrary(uuid, shareCode);
   } catch (e) {
     return {
       type: 'DECK_ALREADY_IN_LIBRARY'

--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -11,8 +11,11 @@ var LibraryApi = {
     return CueApi.fetch(endpoint);
   },
 
-  fetchDeck(uuid : string) {
+  fetchDeck(uuid : string, shareCode?: string) {
     let endpoint = '/api/v1/deck/' + uuid;
+    if (shareCode) {
+      endpoint += '?share_code=' + shareCode
+    }
     console.info('Fetching deck from endpoint: ' + endpoint)
     return CueApi.fetch(endpoint);
   },
@@ -69,16 +72,23 @@ var LibraryApi = {
     return CueApi.fetch(endpoint, 'GET')
   },
 
-	addDeckToLibrary(uuid: string) {
-		let endpoint = '/api/v1/library/add';
-		let method = 'POST'
-		let body = JSON.stringify({
-				uuid: uuid,
-				device: DeviceInfo.getDeviceName(),
-			});
-		console.info('Adding deck "' + uuid + '" to library from endpoint: ' + endpoint)
-		return CueApi.fetch(endpoint, method, body);
-	},
+  getUuidByShareCode(shareCode: string) {
+    let endpoint = '/api/v1/deck/uuid/' + shareCode
+    console.info('Fetching deck UUID from share code "' + shareCode + '" at endpoint:' + endpoint)
+    return CueApi.fetch(endpoint)
+  },
+
+  addDeckToLibrary(uuid: string, shareCode?: string) {
+    let endpoint = '/api/v1/library/add';
+    let method = 'POST'
+    let body = JSON.stringify({
+      uuid: uuid,
+      device: DeviceInfo.getDeviceName(),
+      share_code: shareCode || null,
+    });
+    console.info('Adding deck "' + uuid + '" to library from endpoint: ' + endpoint)
+    return CueApi.fetch(endpoint, method, body);
+  },
 
   overwriteDeck(deck: Deck) {
     let endpoint = '/api/v1/deck/' + deck.uuid

--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -84,7 +84,7 @@ var LibraryApi = {
     let body = JSON.stringify({
       uuid: uuid,
       device: DeviceInfo.getDeviceName(),
-      share_code: shareCode || null,
+      share_code: shareCode,
     });
     console.info('Adding deck "' + uuid + '" to library from endpoint: ' + endpoint)
     return CueApi.fetch(endpoint, method, body);

--- a/Cue/app/common/DeckPreview.js
+++ b/Cue/app/common/DeckPreview.js
@@ -38,6 +38,7 @@ type Props = {
   deck: DeckMetadata,
 
   decks: Array<Deck>,
+  addLibrary: (uuid: string, shareCode: ?string) => any,
 }
 
 class DeckPreview extends React.Component {
@@ -49,6 +50,12 @@ class DeckPreview extends React.Component {
     isLoading: boolean
   }
 
+  _onPressAddDeck = () => {
+    // Add without share code if possible
+    this.props.addLibrary(this.props.deck.uuid,
+                          this.props.deck.public ? null : this.props.deck.share_code)
+  }
+
   constructor(props: Props) {
     super(props)
 
@@ -58,7 +65,7 @@ class DeckPreview extends React.Component {
       isLoading: true
     }
 
-    LibraryApi.fetchDeck(this.props.deck.uuid).then((fullDeck: Deck) => {
+    LibraryApi.fetchDeck(this.props.deck.uuid, this.props.deck.share_code).then((fullDeck: Deck) => {
       this.setState({
         ...this.state,
         isLoading: false,
@@ -109,7 +116,7 @@ class DeckPreview extends React.Component {
           {
             title: 'Add to Library',
             display: 'text',
-            onPress: () => this.props.addLibrary(this.props.deck.uuid)
+            onPress: this._onPressAddDeck,
           }
         ]
       }
@@ -134,7 +141,7 @@ class DeckPreview extends React.Component {
               tabs={previewTabs}
               currentTab={this.state.tab}
               onChange={this.onChange.bind(this)}
-              addLibrary={() => this.props.addLibrary(this.props.deck.uuid)}
+              addLibrary={this._onPressAddDeck}
               deckInLibrary={deck} />
             {tabView}
       </View>
@@ -150,7 +157,7 @@ function select(store) {
 
 function actions(dispatch) {
   return {
-      addLibrary: (uuid: string) => dispatch(addLibrary(uuid)),
+      addLibrary: (uuid: string, shareCode: ?string) => dispatch(addLibrary(uuid, shareCode)),
   };
 }
 

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -126,14 +126,16 @@ class LibraryHome extends React.Component {
   }
 
   _onPressAddDeck = () => {
+    let buttons = [
+      {text: 'Cancel', style: 'cancel'},
+      {text: 'Look Up Share Code', onPress: this._onPressLookUpDeckByShareCode},
+      {text: 'Create New Deck', onPress: this._onPressCreateDeck},
+    ]
+
     Alert.alert(
       Platform.OS === 'android' ? 'Add deck' : 'Add Deck',
       'You can create a new private deck or add a shared deck by entering a share code.',
-      [
-        {text: 'Cancel', style: 'cancel'},
-        {text: 'Look Up Share Code', onPress: this._onPressLookUpDeckByShareCode},
-        {text: 'Create New Deck', onPress: this._onPressCreateDeck},
-      ]
+      Platform.OS === 'android' ? buttons : buttons.reverse(),
     )
   }
 

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -6,6 +6,7 @@ import { View, Text, Image, TouchableOpacity, Navigator, Platform, Alert } from 
 import { connect } from 'react-redux'
 
 import type { Deck } from '../../api/types'
+import LibraryApi from '../../api/Library'
 
 import CuePrompt from '../../common/CuePrompt'
 import CueColors from '../../common/CueColors'
@@ -125,6 +126,44 @@ class LibraryHome extends React.Component {
   }
 
   _onPressAddDeck = () => {
+    Alert.alert(
+      Platform.OS === 'android' ? 'Add deck' : 'Add Deck',
+      'You can create a new private deck or add a shared deck by entering a share code.',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {text: 'Look up share code', onPress: this._onPressLookUpDeckByShareCode},
+        {text: 'Create new deck', onPress: this._onPressCreateDeck},
+      ]
+    )
+  }
+
+  _onPressLookUpDeckByShareCode = () => {
+    CuePrompt.prompt(
+      Platform.OS === 'android' ? 'Look up share code' : 'Look Up Share Code',
+      '',
+      [
+        {text: 'Cancel', style: 'cancel'},
+        {text: 'Look up', onPress: this._onEnterShareCode},
+      ]
+    )
+  }
+
+  _onEnterShareCode = (shareCode: string) => {
+    if (shareCode && shareCode.length) {
+      LibraryApi.getUuidByShareCode(shareCode).then(json => {
+        LibraryApi.fetchDeck(json.uuid, shareCode).then(deck => {
+          this.props.navigator.push({preview: deck})
+        })
+      }).catch(e => {
+        Alert.alert(
+          Platform.OS === 'android' ? 'Deck add error' : 'Deck Add Error',
+          'Could not add deck via share code "' + shareCode + '".',
+        )
+      })
+    }
+  }
+
+  _onPressCreateDeck = () => {
     CuePrompt.prompt(
       Platform.OS === 'android' ? 'Create new deck' : 'Create New Deck',
       '',

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -131,8 +131,8 @@ class LibraryHome extends React.Component {
       'You can create a new private deck or add a shared deck by entering a share code.',
       [
         {text: 'Cancel', style: 'cancel'},
-        {text: 'Look up share code', onPress: this._onPressLookUpDeckByShareCode},
-        {text: 'Create new deck', onPress: this._onPressCreateDeck},
+        {text: 'Look Up Share Code', onPress: this._onPressLookUpDeckByShareCode},
+        {text: 'Create New Deck', onPress: this._onPressCreateDeck},
       ]
     )
   }
@@ -143,7 +143,7 @@ class LibraryHome extends React.Component {
       '',
       [
         {text: 'Cancel', style: 'cancel'},
-        {text: 'Look up', onPress: this._onEnterShareCode},
+        {text: 'Look Up', onPress: this._onEnterShareCode},
       ]
     )
   }
@@ -151,12 +151,12 @@ class LibraryHome extends React.Component {
   _onEnterShareCode = (shareCode: string) => {
     if (shareCode && shareCode.length) {
       LibraryApi.getUuidByShareCode(shareCode).then(json => {
-        LibraryApi.fetchDeck(json.uuid, shareCode).then(deck => {
-          this.props.navigator.push({preview: deck})
-        })
+        return LibraryApi.fetchDeck(json.uuid, shareCode)
+      }).then(deck => {
+        this.props.navigator.push({preview: deck})
       }).catch(e => {
         Alert.alert(
-          Platform.OS === 'android' ? 'Deck add error' : 'Deck Add Error',
+          Platform.OS === 'android' ? 'Failed to look up share code' : 'Failed to Look Up Share Code',
           'Could not add deck via share code "' + shareCode + '".',
         )
       })


### PR DESCRIPTION
- Added flow mentioned in spec
- Needed to add optional `shareCode` param to several functions
  - Without the share code, you aren't allowed to fetch the deck if it's just shared and not public

Take a look at the screenshots

Need some iOS QA pls.

New flow when hitting the '+' or 'Add' button:
![shareadd1](https://cloud.githubusercontent.com/assets/6856391/24282144/1fe7f4cc-1034-11e7-845f-7f01b685ae99.png)

Prompt to enter share code:
![shareadd2](https://cloud.githubusercontent.com/assets/6856391/24282145/1feca2ec-1034-11e7-9c31-330388807cb0.png)

Deck preview:
![sharedadd3](https://cloud.githubusercontent.com/assets/6856391/24282149/24c3243a-1034-11e7-9d0b-815abe3fff80.png)

What happens if you enter a bad share code:
![shareadd4](https://cloud.githubusercontent.com/assets/6856391/24282153/29b5cb00-1034-11e7-9dd4-8d7186c781be.png)

Closes #144