### PR TITLE
upgrade flow

### DIFF
--- a/Cue/.flowconfig
+++ b/Cue/.flowconfig
@@ -32,6 +32,12 @@ munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 
+module.file_ext=.android.js
+module.file_ext=.ios.js
+module.file_ext=.js
+module.file_ext=.jsx
+module.file_ext=.json
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
@@ -41,3 +47,6 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-8]\\|1[0-9]\\|[1-2
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 unsafe.enable_getters_and_setters=true
+
+[version]
+^0.38.0

--- a/Cue/package.json
+++ b/Cue/package.json
@@ -33,7 +33,7 @@
     "babel-eslint": "^7.1.1",
     "babel-jest": "18.0.0",
     "eslint": "^3.16.0",
-    "flow-bin": "^0.37.0",
+    "flow-bin": "^0.38.0",
     "jest": "18.1.0",
     "react-test-renderer": "15.4.2"
   },


### PR DESCRIPTION
Upgrade flow to 0.38.

Was getting >100 flow errors, down to ~60. 

Needed to updated flow version since upgrade of react-native to 0.42

Note: I had to clean my node_modules folder and `npm install` for this to work with atom