### PR TITLE
Make Deck Edit Options Dynamic

### DIFF
--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -99,7 +99,15 @@ class DeckUUIDHandler(BaseHandler):
                         card = CardPolicy.belongs_to(action['card_id'], deck.uuid, connector)
                         if card is None:
                             raise ValueError  # card does not belong to deck
-                        card.edit(deck.uuid, action['front'], action['back'], action['position'])
+
+                        # Make edits.
+                        if action.get('front') is not None or action.get('back') is not None:
+                            card.edit(deck.uuid, action.get('front'), action.get('back'))
+
+                        # Move card.
+                        if action.get('position') is not None:
+                            card.move(deck.uuid, action['position'])
+
                     elif action['action'] == 'delete':
                         card = CardPolicy.belongs_to(action['card_id'], deck.uuid, connector)
                         if card is None:

--- a/Server/App/model/card.py
+++ b/Server/App/model/card.py
@@ -16,9 +16,23 @@ class Card(object):
         connector.call_procedure_transactionally(procedure_name, uuid, deck_id, front, back, position)
         return Card(uuid, connector)
 
-    def edit(self, deck_id, front, back, position):
-        self.connector.call_procedure_transactionally(
-            'EDIT_CARD', self.uuid, deck_id, front, back, position)
+    def edit(self, deck_id, front=None, back=None):
+        query = 'UPDATE Card SET {} WHERE deck_id=%s AND uuid=%s'
+        sub_list = []
+        arg_list = []
+        if front is not None:
+            sub_list.append('front=%s')
+            arg_list.append(front)
+        if back is not None:
+            sub_list.append('back=%s')
+            arg_list.append(back)
+
+        if len(sub_list) > 0:
+            self.connector.query_transactionally(query.format(','.join(sub_list)),
+                                                 *(arg_list + [deck_id, self.uuid]))
+
+    def move(self, deck_id, position):
+        self.connector.call_procedure_transactionally('MOVE_CARD', self.uuid, deck_id, position)
 
     def delete(self, deck_id):
         self.connector.call_procedure_transactionally(

--- a/Server/App/model/deck.py
+++ b/Server/App/model/deck.py
@@ -20,7 +20,8 @@ class Deck(object):
         deck_id = generate_uuid()
         try:
             connector.begin_transaction()
-            connector.call_procedure('CREATE_DECK', deck_id, name, user_id, device, ','.join(tags))
+            connector.call_procedure('CREATE_DECK', deck_id, name, user_id, device,
+                                     ','.join(tags) if len(tags) > 0 else None)
             for index in xrange(len(cards)):
                 Card.create(deck_id, cards[index]['front'], cards[index]['back'], index,
                             reposition=False, connector=connector)

--- a/Server/SQL/Migrations/2017-03-24_08-50.sql
+++ b/Server/SQL/Migrations/2017-03-24_08-50.sql
@@ -1,0 +1,8 @@
+USE Cue;
+START TRANSACTION;
+-- BEGIN MIGRATION --
+
+UPDATE Deck SET tags_delimited = NULL WHERE tags_delimited = '';
+
+-- END MIGRATION --
+COMMIT;

--- a/Server/SQL/procedures.sql
+++ b/Server/SQL/procedures.sql
@@ -92,17 +92,6 @@ BEGIN
 END$$
 
 
--- Edit a card and update card positions
-CREATE PROCEDURE EDIT_CARD
-(
-    IN u VARCHAR(36), IN d VARCHAR(36), IN f VARCHAR(255), IN b VARCHAR(255), IN p INTEGER
-)
-BEGIN
-    UPDATE Card SET front=f, back=b WHERE uuid=u AND deck_id=d;
-    CALL MOVE_CARD(u, d, p);
-END$$
-
-
 -- Move a card to a new position in a deck.
 CREATE PROCEDURE MOVE_CARD(IN u VARCHAR(36), IN d VARCHAR(36), IN p INTEGER)
 BEGIN

--- a/Spec/API.md
+++ b/Spec/API.md
@@ -147,11 +147,11 @@ Edit action:
 ```
 {
     "action": "edit",
-    "card_id": "<card-id>"
+    "card_id": "<card-id>"[,
     "front": "<Q>",
     "back": "<A>",
     "position": <pos>,
-    "needs_review": true | false
+    "needs_review": true | false]
 }
 ```
 


### PR DESCRIPTION
- Made all parts of the edit action optional so that you only modify the part of the card that you need to modify
- Decks will now be created with empty tags rather than an empty string
- Added a migration for all decks that have an empty string as their tags delimited
- Removed `EDIT_CARD` procedure

Closes #163