### PR TITLE
New Deck Play Options

### DIFF
--- a/Cue/app/CueNavigator.js
+++ b/Cue/app/CueNavigator.js
@@ -103,7 +103,7 @@ var CueNavigator = React.createClass({
     } else if (route.sharingOptions) {
       return <DeckSharingOptions navigator={navigator} deck={route.sharingOptions} {...route} />
     } else if (route.playDeckSetup) {
-      return <PlayDeckSetupView navigator={navigator} deck={route.playDeckSetup} {...route} />
+      return <PlayDeckSetupView navigator={navigator} deck={route.playDeckSetup} flagFilter={route.flagFilter} {...route} />
     } else if (route.playDeck) {
       return <PlayDeckView navigator={navigator} deck={route.playDeck} {...route} />
     } else if (route.preview) {

--- a/Cue/app/CueNavigator.js
+++ b/Cue/app/CueNavigator.js
@@ -103,7 +103,7 @@ var CueNavigator = React.createClass({
     } else if (route.sharingOptions) {
       return <DeckSharingOptions navigator={navigator} deck={route.sharingOptions} {...route} />
     } else if (route.playDeckSetup) {
-      return <PlayDeckSetupView navigator={navigator} deck={route.playDeckSetup} flagFilter={route.flagFilter} {...route} />
+      return <PlayDeckSetupView navigator={navigator} deck={route.playDeckSetup} {...route} />
     } else if (route.playDeck) {
       return <PlayDeckView navigator={navigator} deck={route.playDeck} {...route} />
     } else if (route.preview) {

--- a/Cue/app/common/CueColors.js
+++ b/Cue/app/common/CueColors.js
@@ -5,6 +5,7 @@
 module.exports = {
   primaryAccent: '#51A7F9',
 
+  primaryTintEvenLighter: '#BED1EA',
   primaryTintLighter: '#DEE8F5',
   primaryTint: '#0365C0',       // or Material Blue 600 '#1E88E5'?
   primaryTintDark: '#225095',   // or Material Blue 800 '#1565C0'?

--- a/Cue/app/common/CueColors.js
+++ b/Cue/app/common/CueColors.js
@@ -5,8 +5,8 @@
 module.exports = {
   primaryAccent: '#51A7F9',
 
-  primaryTintEvenLighter: '#BED1EA',
   primaryTintLighter: '#DEE8F5',
+  primaryTintSlightlyLighter: '#BED1EA',
   primaryTint: '#0365C0',       // or Material Blue 600 '#1E88E5'?
   primaryTintDark: '#225095',   // or Material Blue 800 '#1565C0'?
   primaryTintDarker: '#193C70', // or Material Blue 900 '#0D47A1'?

--- a/Cue/app/common/SwitchTableRow.js
+++ b/Cue/app/common/SwitchTableRow.js
@@ -1,0 +1,49 @@
+// @flow
+
+import React from 'react'
+import { Platform, Switch, Text } from 'react-native'
+
+import CueColors from './CueColors'
+
+import TableRow from './TableRow'
+
+
+const styles = {
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: Platform.OS === 'android' ? 16 : undefined,
+  },
+  text: {
+    color: CueColors.primaryText,
+    fontSize: Platform.OS === 'android' ? 16 : 17,
+  },
+}
+
+
+export default class SwitchTableRow extends React.Component {
+  props: {
+    text: string,
+    value: boolean,
+    onPress?: (value: boolean) => void,
+  }
+
+  render() {
+    return (
+      <TableRow style={styles.container} >
+        <Text style={styles.text}>
+          {this.props.text}
+        </Text>
+        <Switch
+          onTintColor={CueColors.primaryTint}
+          tintColor={CueColors.lightGrey}
+          thumbTintColor={(Platform.OS === 'android' && this.props.value) ?
+                            CueColors.primaryTint : CueColors.veryLightGrey}
+          value={this.props.value}
+          onValueChange={this.props.onPress} />
+      </TableRow>
+    )
+  }
+}

--- a/Cue/app/common/SwitchTableRow.js
+++ b/Cue/app/common/SwitchTableRow.js
@@ -32,15 +32,17 @@ export default class SwitchTableRow extends React.Component {
 
   render() {
     return (
-      <TableRow style={styles.container} >
+      <TableRow
+        style={styles.container}
+        onPress={() => this.props.onPress(!this.props.value)}
+        disabled={Platform.OS !== 'android'} >
         <Text style={styles.text}>
           {this.props.text}
         </Text>
         <Switch
-          onTintColor={CueColors.primaryTint}
-          tintColor={CueColors.lightGrey}
+          onTintColor={Platform.OS === 'android' ? CueColors.primaryTintEvenLighter : CueColors.primaryTint}
           thumbTintColor={(Platform.OS === 'android' && this.props.value) ?
-                            CueColors.primaryTint : CueColors.veryLightGrey}
+                            CueColors.primaryTint : undefined}
           value={this.props.value}
           onValueChange={this.props.onPress} />
       </TableRow>

--- a/Cue/app/common/SwitchTableRow.js
+++ b/Cue/app/common/SwitchTableRow.js
@@ -34,7 +34,7 @@ export default class SwitchTableRow extends React.Component {
     return (
       <TableRow
         style={styles.container}
-        onPress={() => this.props.onPress(!this.props.value)}
+        onPress={() => this.props.onPress && this.props.onPress(!this.props.value)}
         disabled={Platform.OS !== 'android'} >
         <Text style={styles.text}>
           {this.props.text}

--- a/Cue/app/common/SwitchTableRow.js
+++ b/Cue/app/common/SwitchTableRow.js
@@ -40,7 +40,7 @@ export default class SwitchTableRow extends React.Component {
           {this.props.text}
         </Text>
         <Switch
-          onTintColor={Platform.OS === 'android' ? CueColors.primaryTintEvenLighter : CueColors.primaryTint}
+          onTintColor={Platform.OS === 'android' ? CueColors.primaryTintSlightlyLighter : CueColors.primaryTint}
           thumbTintColor={(Platform.OS === 'android' && this.props.value) ?
                             CueColors.primaryTint : undefined}
           value={this.props.value}

--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -161,7 +161,7 @@ class DeckView extends React.Component {
         [{text: 'OK', style: 'cancel'}]
       )
     } else {
-      this.props.navigator.push({ playDeckSetup: this.state.deck })
+      this.props.navigator.push({ playDeckSetup: this.state.deck, flagFilter: this.state.isFiltering })
     }
   }
 

--- a/Cue/app/tabs/library/play/PlayDeckSetupView.js
+++ b/Cue/app/tabs/library/play/PlayDeckSetupView.js
@@ -115,7 +115,7 @@ export default class PlayDeckSetupView extends React.Component {
     return (
       <View>
         <TableHeader
-          text={'Modifiers:'} />
+          text={'Options:'} />
         <SwitchTableRow
           text={'Answer side first'}
           value={this.state.answerFirst}

--- a/Cue/app/tabs/library/play/PlayDeckSetupView.js
+++ b/Cue/app/tabs/library/play/PlayDeckSetupView.js
@@ -17,7 +17,6 @@ import SwitchTableRow from '../../../common/SwitchTableRow'
 const styles = {
   container: {
     flex: 1,
-    paddingBottom: 40,
     backgroundColor: Platform.OS === 'android' ? 'white' : CueColors.coolLightGrey,
   },
 
@@ -217,7 +216,9 @@ export default class PlayDeckSetupView extends React.Component {
           leftItem={leftItem}
           title={'Play “' + this.props.deck.name + '”'}
           rightItems={rightItems} />
-        <ScrollView style={styles.container}>
+        <ScrollView
+          style={styles.container}
+          contentContainerStyle={{paddingBottom: 40}}>
           {this._renderPlaybackOptions()}
           {this._renderCustomSelection()}
           {this._renderModifiers()}

--- a/Cue/app/tabs/library/play/PlayDeckSetupView.js
+++ b/Cue/app/tabs/library/play/PlayDeckSetupView.js
@@ -12,6 +12,7 @@ import CueIcons from '../../../common/CueIcons'
 import TableHeader from '../../../common/TableHeader'
 import TableRow from '../../../common/TableRow'
 import SelectableTextTableRow from '../../../common/SelectableTextTableRow'
+import SwitchTableRow from '../../../common/SwitchTableRow'
 
 const styles = {
   container: {
@@ -28,16 +29,18 @@ const styles = {
 type Props = {
   navigator: Navigator,
   deck: Deck,
+  flagFilter: boolean,
 }
 
-type PlaybackOption = 'sequential' | 'shuffled' | 'custom'
+type PlaybackOption = 'sequential' | 'shuffled' | 'custom' | 'flagged'
 
 export default class PlayDeckSetupView extends React.Component {
   props: Props
 
   state: {
     playbackOption: PlaybackOption,
-    customStartIndex: number
+    customStartIndex: number,
+    answerFirst: boolean,
   }
 
   _onPlaybackOptionSelected = (option: PlaybackOption) => {
@@ -51,8 +54,9 @@ export default class PlayDeckSetupView extends React.Component {
     super(props)
 
     this.state = {
-      playbackOption: 'sequential',
-      customStartIndex: 0
+      playbackOption: this.props.flagFilter ? 'flagged' : 'sequential',
+      customStartIndex: 0,
+      answerFirst: false
     }
   }
 
@@ -73,6 +77,10 @@ export default class PlayDeckSetupView extends React.Component {
           text={'Beginning at a specific card'}
           selected={this.state.playbackOption === 'custom'}
           onPress={() => { this._onPlaybackOptionSelected('custom') }} />
+        <SelectableTextTableRow
+          text={'With flagged cards only'}
+          selected={this.state.playbackOption === 'flagged'}
+          onPress={() => { this._onPlaybackOptionSelected('flagged') }} />
       </View>
     )
   }
@@ -103,6 +111,19 @@ export default class PlayDeckSetupView extends React.Component {
     }
   }
 
+  _renderModifiers = () => {
+    return (
+      <View>
+        <TableHeader
+          text={'Modifiers:'} />
+        <SwitchTableRow
+          text={'Answer side first'}
+          value={this.state.answerFirst}
+          onPress={value => this.setState({...this.state, answerFirst: value})} />
+      </View>
+    )
+  }
+
   render() {
     let leftItem = {
       title: 'Cancel',
@@ -120,7 +141,9 @@ export default class PlayDeckSetupView extends React.Component {
             shuffle: this.state.playbackOption === 'shuffled',
             startIndex: this.state.playbackOption === 'custom'
               ? this.state.customStartIndex
-              : undefined
+              : undefined,
+            flaggedOnly: this.state.playbackOption === 'flagged',
+            answerFirst: this.state.answerFirst,
           })}
       }
     ]
@@ -133,6 +156,7 @@ export default class PlayDeckSetupView extends React.Component {
         <ScrollView style={styles.container}>
           {this._renderPlaybackOptions()}
           {this._renderCustomSelection()}
+          {this._renderModifiers()}
         </ScrollView>
       </View>
     )

--- a/Cue/app/tabs/library/play/PlayDeckSetupView.js
+++ b/Cue/app/tabs/library/play/PlayDeckSetupView.js
@@ -17,6 +17,7 @@ import SwitchTableRow from '../../../common/SwitchTableRow'
 const styles = {
   container: {
     flex: 1,
+    paddingBottom: 40,
     backgroundColor: Platform.OS === 'android' ? 'white' : CueColors.coolLightGrey,
   },
 
@@ -53,7 +54,12 @@ export default class PlayDeckSetupView extends React.Component {
       flaggedOnly: this.props.flagFilter,
       answerFirst: false,
       customStartIndex: 0,
+      filteredCards: [],
     }
+
+    // Need to generate the filters with the state that is about to be set, but the cards
+    // need to be part of the state, so we have a bit of a chicken and egg problem.
+    // As a result, we have to create a proto-state to pass to this method.
     state.filteredCards = this._generateDeckFilter(state)(this.props.deck.cards || [])
     this.state = state
   }
@@ -103,6 +109,10 @@ export default class PlayDeckSetupView extends React.Component {
       ...option,
       customStartIndex: 0,
     }
+
+    // Need to generate the filters with the state that is about to be set, but the cards
+    // need to be part of the state, so we have a bit of a chicken and egg problem.
+    // As a result, we have to create a proto-state to pass to this method.
     newState.filteredCards = this._generateDeckFilter(newState)(this.props.deck.cards || [])
 
     this.setState(newState)
@@ -112,7 +122,7 @@ export default class PlayDeckSetupView extends React.Component {
     if (this.state.filteredCards.length === 0) {
       Alert.alert(
         Platform.OS === 'android' ? 'No cards to play' : 'No Cards To Play',
-        'Try turning off the "Flagged cards only" option'
+        'Try turning off the “Flagged cards only” option.'
       )
       return
     }

--- a/Cue/app/tabs/library/play/PlayDeckSetupView.js
+++ b/Cue/app/tabs/library/play/PlayDeckSetupView.js
@@ -137,7 +137,7 @@ export default class PlayDeckSetupView extends React.Component {
           selected={this.state.playbackOption === 'shuffled'}
           onPress={() => this._setFilterOption({playbackOption: 'shuffled'})} />
         <SelectableTextTableRow
-          text={'Start from a specific card'}
+          text={'Beginning at a specific card'}
           selected={this.state.playbackOption === 'custom'}
           onPress={() => this._setFilterOption({playbackOption: 'custom'})} />
       </View>

--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -153,22 +153,12 @@ class PlayDeckView extends React.Component {
     StatusBar.setHidden(false)
   }
 
-  _flaggedOnly(array: Array<*>): Array<*> {
-    return array.slice(0).filter(item => item.needs_review)
+  _flaggedOnly(array: Array<Deck>): Array<Deck> {
+    return array.filter(item => item.needs_review)
   }
 
-  _answerFirst(array: Array<*>): Array<*> {
-    let ret = []
-
-    for (let i = 0; i < array.length; i++) {
-      ret.push({
-        ...array[i],
-        front: array[i].back,
-        back: array[i].front
-      })
-    }
-
-    return ret
+  _answerFirst(array: Array<Deck>): Array<Deck> {
+    return array.map(deck => { return {...deck, front: deck.back, back: deck.front} })
   }
 
   _shuffled(array: Array<*>): Array<*> {

--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -68,10 +68,8 @@ const baseSpringConfig = {
 type Props = {
   navigator: Navigator,
   deck: Deck,
-  shuffle?: boolean,
-  startIndex?: number,
-  flaggedOnly?: boolean,
-  answerFirst?: boolean,
+  startIndex: number,
+  cardFilter: (Array<Card>) => Array<Card>,
 
   // From Redux:
   flagCard: (deckUuid: string, cardUuid: string, flag: boolean) => any
@@ -105,18 +103,10 @@ class PlayDeckView extends React.Component {
   constructor(props: Props) {
     super(props)
 
-    // Take a snapshot of the Deck in props
-    let cards = (this.props.deck.cards || []).slice(0)
-
-    // Process play options
-    if (this.props.shuffle) cards = this._shuffled(cards)
-    else if (this.props.flaggedOnly) cards = this._flaggedOnly(cards)
-
-    // Process modifiers
-    if (this.props.answerFirst) cards = this._answerFirst(cards)
+    let cards = this.props.cardFilter(this.props.deck.cards || [])
 
     this.state = {
-      index: this.props.startIndex || 0,
+      index: this.props.startIndex,
       cards: cards,
       cardXY: new Animated.ValueXY(),
       cardOpacity: new Animated.Value(0),
@@ -151,27 +141,6 @@ class PlayDeckView extends React.Component {
 
   componentWillUnmount() {
     StatusBar.setHidden(false)
-  }
-
-  _flaggedOnly(array: Array<Deck>): Array<Deck> {
-    return array.filter(item => item.needs_review)
-  }
-
-  _answerFirst(array: Array<Deck>): Array<Deck> {
-    return array.map(deck => { return {...deck, front: deck.back, back: deck.front} })
-  }
-
-  _shuffled(array: Array<*>): Array<*> {
-    let ret = array.slice(0)
-
-    for (let i = ret.length - 1; i > 0; i--) {
-      let j = Math.floor(Math.random() * (i + 1))
-      let temp = ret[i]
-      ret[i] = ret[j]
-      ret[j] = temp
-    }
-
-    return ret
   }
 
 

--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -70,6 +70,8 @@ type Props = {
   deck: Deck,
   shuffle?: boolean,
   startIndex?: number,
+  flaggedOnly?: boolean,
+  answerFirst?: boolean,
 
   // From Redux:
   flagCard: (deckUuid: string, cardUuid: string, flag: boolean) => any
@@ -105,7 +107,13 @@ class PlayDeckView extends React.Component {
 
     // Take a snapshot of the Deck in props
     let cards = (this.props.deck.cards || []).slice(0)
-    cards = this.props.shuffle ? this._shuffled(cards) : cards
+
+    // Process play options
+    if (this.props.shuffle) cards = this._shuffled(cards)
+    else if (this.props.flaggedOnly) cards = this._flaggedOnly(cards)
+
+    // Process modifiers
+    if (this.props.answerFirst) cards = this._answerFirst(cards)
 
     this.state = {
       index: this.props.startIndex || 0,
@@ -143,6 +151,24 @@ class PlayDeckView extends React.Component {
 
   componentWillUnmount() {
     StatusBar.setHidden(false)
+  }
+
+  _flaggedOnly(array: Array<*>): Array<*> {
+    return array.slice(0).filter(item => item.needs_review)
+  }
+
+  _answerFirst(array: Array<*>): Array<*> {
+    let ret = []
+
+    for (let i = 0; i < array.length; i++) {
+      ret.push({
+        ...array[i],
+        front: array[i].back,
+        back: array[i].front
+      })
+    }
+
+    return ret
   }
 
   _shuffled(array: Array<*>): Array<*> {


### PR DESCRIPTION
- Added new play option "With flagged cards only"
  - This option is automatically selected if the user was viewing the deck with the filter option turned on
- Added toggle-able modifiers (just one for now: "Answer side first")
- Made a new table row class for switches

Closes #101

Comments:
- No idea what this is going to look like on iOS.
- Style suggestions welcome, I just threw together what looked right to me
- Is the navigator stuff too messy?
- Thought modifiers would be nice since you might want to use answer-side-first with different play modes
  - Have to be careful about modifiers you make (i.e. make sure they don't conflict with play options / other modifiers)
- Do we need to be slicing our already sliced copy of the cards in `PlayDeckView`?

Modifier toggle off:
![playsetup1](https://cloud.githubusercontent.com/assets/6856391/24305469/71f8629c-1093-11e7-9229-afe3f8208fdc.png)

Modifier toggle on:
![playsetup2](https://cloud.githubusercontent.com/assets/6856391/24305470/71f955d0-1093-11e7-8b50-68f0c517fe48.png)

Picker in the middle:
![playsetup3](https://cloud.githubusercontent.com/assets/6856391/24305926/03ac9662-1095-11e7-9e52-abc17d2ff3a7.png)

