### PR TITLE
Add ability to rate and copy decks

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -140,7 +140,6 @@ async function syncDeck(change) : PromiseAction {
     change = {...change, user_data_version: response.user_data_version}
   } else if (change.action === "rate") {
     await LibraryApi.rateDeck(change.uuid, change.user_rating)
-    change = {...change}
   }
   return {
     type: 'DECK_SYNCED',

--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -64,6 +64,17 @@ function flagCard(deckUuid: string, cardUuid: string, needs_review: Boolean): Ac
   }
   return {
     type: 'CARD_FLAGGED',
+    change,
+  }
+}
+
+function rateDeck(uuid: string, user_rating: number): Action {
+  let change = {
+    uuid,
+    user_rating
+  }
+  return {
+    type: 'DECK_RATED',
     change
   }
 }
@@ -127,6 +138,9 @@ async function syncDeck(change) : PromiseAction {
   } else if (change.action === "flag") {
     let response = await LibraryApi.flagCard(change)
     change = {...change, user_data_version: response.user_data_version}
+  } else if (change.action === "rate") {
+    await LibraryApi.rateDeck(change.uuid, change.user_rating)
+    change = {...change}
   }
   return {
     type: 'DECK_SYNCED',
@@ -179,5 +193,5 @@ function copyDeck(localDeck: Deck) : Action {
 
 module.exports = {
   loadLibrary, createDeck, deleteDeck, editDeck, recordShareCode, resolveConflict,
-  syncDeck, syncLibrary, addLibrary, clearInaccessibleDecks, copyDeck, flagCard
+  syncDeck, syncLibrary, addLibrary, clearInaccessibleDecks, copyDeck, flagCard, rateDeck
 };

--- a/Cue/app/actions/types.js
+++ b/Cue/app/actions/types.js
@@ -20,7 +20,7 @@ export type Action =
 	| { type: 'DECK_ALREADY_IN_LIBRARY'}
 	| { type: 'DECK_ADDED_TO_LIBRARY', addedDeck: Deck}
 	| { type: 'CLEAR_INACCESSIBLE_DECKS'}
-	| { type: 'CARD_RATED', change: {uuid: string, userRating: number}}
+	| { type: 'DECK_RATED', change: {uuid: string, userRating: number}}
 	;
 
 export type Dispatch = (action: Action | ThunkAction | PromiseAction | Array<Action>) => any;

--- a/Cue/app/actions/types.js
+++ b/Cue/app/actions/types.js
@@ -20,7 +20,8 @@ export type Action =
 	| { type: 'DECK_ALREADY_IN_LIBRARY'}
 	| { type: 'DECK_ADDED_TO_LIBRARY', addedDeck: Deck}
 	| { type: 'CLEAR_INACCESSIBLE_DECKS'}
-;
+	| { type: 'CARD_RATED', change: {uuid: string, userRating: number}}
+	;
 
 export type Dispatch = (action: Action | ThunkAction | PromiseAction | Array<Action>) => any;
 export type GetState = () => Object;

--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -125,6 +125,16 @@ var LibraryApi = {
     })
     console.info('Flagging card "' + body + '" at endpoint: ' + endpoint)
     return CueApi.fetch(endpoint, method, body);
+  },
+
+  rateDeck(uuid: string, rating: number) {
+    let endpoint = '/api/v1/deck/' + uuid + '/rate'
+    let method = 'POST'
+    let body = JSON.stringify({
+      rating
+    })
+    console.info('Rating deck "' + uuid + '" ' + rating + ' at endpoint: ' + endpoint)
+    return CueApi.fetch(endpoint, method, body);
   }
 
 }

--- a/Cue/app/api/types.js
+++ b/Cue/app/api/types.js
@@ -13,6 +13,7 @@ export type DeckMetadata = {
   name: string,
   author: string,
   rating: number,
+  user_rating?: number,
   num_ratings: number,
   num_cards: number,
   tags: Array<string>,

--- a/Cue/app/reducers/library.js
+++ b/Cue/app/reducers/library.js
@@ -122,6 +122,33 @@ function library(state: State = initialState, action: Action): State {
       })
     }
 
+  } else if (action.type === 'DECK_RATED') {
+    let change = action.change
+
+    let deckIndex = decks.findIndex(deck => deck.uuid == change.uuid)
+    if (decks[deckIndex]) {
+      let oldRating = decks[deckIndex].user_rating ? decks[deckIndex].user_rating : 0
+      decks[deckIndex] = {
+        ...decks[deckIndex],
+        rating: decks[deckIndex].rating + change.user_rating - oldRating,
+        num_ratings: decks[deckIndex].num_ratings + (oldRating ? 0 : 1),
+        user_rating: change.user_rating
+      }
+    }
+
+    let changeIndex = localChanges.findIndex(deck => deck.uuid == change.uuid && deck.user_rating)
+    if (localChanges[changeIndex]) {
+      localChanges[changeIndex] = {
+        ...localChanges[changeIndex],
+        user_rating: change.user_rating,
+      }
+    } else {
+      localChanges.push({
+        ...change,
+        action: 'rate',
+      })
+    }
+
   } else if (action.type === 'SHARE_CODE_GENERATED') {
     let deck = decks.find((deck: Deck) => deck.uuid === action.uuid)
     deck.share_code = action.code

--- a/Cue/app/tabs/discover/DiscoverDeckCarousel.js
+++ b/Cue/app/tabs/discover/DiscoverDeckCarousel.js
@@ -27,16 +27,24 @@ export default class DiscoverDeckCarousel extends React.Component {
     dataSource: ListView.DataSource
   }
 
+  ds: ListView.DataSource
+
   constructor(props: Props) {
     super(props)
 
-    let ds = new ListView.DataSource({
+    this.ds = new ListView.DataSource({
       rowHasChanged: (r1, r2) => r1 !== r2
     })
 
     this.state = {
-      dataSource: ds.cloneWithRows(this.props.decks)
+      dataSource: this.ds.cloneWithRows(this.props.decks)
     }
+  }
+
+  componentWillReceiveProps(newProps: Props) {
+    this.setState({
+      dataSource: this.ds.cloneWithRows(newProps.decks)
+    })
   }
 
   render() {

--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -121,7 +121,10 @@ class DeckView extends React.Component {
         + ' The copied deck will no longer receive updates from the original owner.',
       [
         {text: 'Cancel', style: 'cancel'},
-        {text: 'Copy', onPress: () => this.props.copyDeck(this.state.deck)}
+        {text: 'Copy', onPress: () => {
+          let action = this.props.copyDeck(this.state.deck)
+          this.props.navigator.push({deck: action.deck})
+        }}
       ]
     )
   }

--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -97,7 +97,7 @@ class DeckView extends React.Component {
   _rateDeck = () => {
     let buttons = [
       {text: 'Recommend',  onPress: () => this.props.rateDeck(this.state.deck.uuid, 1)},
-      {text: 'Would not Recommend', onPress: () => this.props.rateDeck(this.state.deck.uuid, -1)},
+      {text: 'Would Not Recommend', onPress: () => this.props.rateDeck(this.state.deck.uuid, -1)},
       {text: 'Cancel', style: 'cancel'},
     ]
 
@@ -123,7 +123,7 @@ class DeckView extends React.Component {
         {text: 'Cancel', style: 'cancel'},
         {text: 'Copy', onPress: () => {
           let action = this.props.copyDeck(this.state.deck)
-          this.props.navigator.push({deck: action.deck})
+          this.props.navigator.replace({deck: action.deck})
         }}
       ]
     )

--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -95,28 +95,32 @@ class DeckView extends React.Component {
   }
 
   _rateDeck = () => {
+    let buttons = [
+      {text: 'Recommend',  onPress: () => this.props.rateDeck(this.state.deck.uuid, 1)},
+      {text: 'Would not Recommend', onPress: () => this.props.rateDeck(this.state.deck.uuid, -1)},
+      {text: 'Cancel', style: 'cancel'},
+    ]
+
     Alert.alert(
       (Platform.OS === 'android'
         ? 'Rate this deck'
         : 'Rate This Deck'),
       'Would you recommend this deck to others?',
-      [
-        {text: 'Cancel', style: 'destructive'},
-        {text: 'Would not Recommend', onPress: () => this.props.rateDeck(this.state.deck.uuid, -1)},
-        {text: 'Recommend',  onPress: () => this.props.rateDeck(this.state.deck.uuid, 1)},
-      ],
-
+      (Platform.OS === 'android'
+        ? buttons.reverse()
+        : buttons)
     )
   }
 
   _copyDeck = () => {
     Alert.alert(
       (Platform.OS === 'android'
-        ? 'Are you sure you want to copy this deck?'
-        : 'Are You Sure You Want to Copy This Deck?'),
-      'Copying will create a private version of this deck in your library',
+        ? 'Copy this deck?'
+        : 'Copy This Deck?'),
+      'Copying will create a private version of this deck in your library.'
+        + ' The copied deck will no longer receive updates from the original owner.',
       [
-        {text: 'Cancel', style: 'destructive'},
+        {text: 'Cancel', style: 'cancel'},
         {text: 'Copy', onPress: () => this.props.copyDeck(this.state.deck)}
       ]
     )
@@ -214,7 +218,7 @@ class DeckView extends React.Component {
     return backItem
   }
 
-  _getRightItems = ({addItem, copyItem, editItem, filterItem, shareItem}) => {
+  _getRightItems = ({addItem, copyItem, rateItem, editItem, filterItem, shareItem}) => {
     if (Platform.OS === 'android') {
       if (this.state.deck.accession === 'private') {
         return [


### PR DESCRIPTION
Add overflow icon in android to rate+copy decks, and an additional button on IOS to rate.

Currently, no way to see how you previously rated a deck. Open to suggestions as to how to indicate it in UI.

![copy](https://cloud.githubusercontent.com/assets/7501968/24316639/0c234c9c-10c6-11e7-9947-27972efdf97c.PNG)

![rate](https://cloud.githubusercontent.com/assets/7501968/24316640/0f65b016-10c6-11e7-82e0-5687dbd4330c.PNG)

Closes #170 
Closes #126 