### PR TITLE
Fix header colour in launch screen on iOS

### DIFF
--- a/Cue/ios/Cue/Base.lproj/LaunchScreen.xib
+++ b/Cue/ios/Cue/Base.lproj/LaunchScreen.xib
@@ -17,7 +17,7 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lpM-Lb-f0J">
                     <rect key="frame" x="0.0" y="0.0" width="480" height="64"/>
-                    <color key="backgroundColor" red="0.011764705882352941" green="0.396078431372549" blue="0.75294117647058822" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.047058823529411764" green="0.396078431372549" blue="0.75294117647058822" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="b6n-ou-hv4"/>
                     </constraints>


### PR DESCRIPTION
Because of how colour management works on iOS vs in Interface Builder <sub>ಠ__ಠ</sub> the first time I set the colour of the fake header on the launch screen, it didn't actually match the colour of the real header... Should be fixed now.

Before:
![simulator screen shot mar 25 2017 12 27 29 am](https://cloud.githubusercontent.com/assets/13400887/24319439/25c635ac-10f2-11e7-98ef-432ac69fc7c7.png)

After:
![simulator screen shot mar 25 2017 12 28 01 am](https://cloud.githubusercontent.com/assets/13400887/24319440/25c8d578-10f2-11e7-97f2-68363183b11b.png)

Actual colour for reference:
![simulator screen shot mar 25 2017 12 27 06 am](https://cloud.githubusercontent.com/assets/13400887/24319441/27e46f48-10f2-11e7-9fdc-509704e058dc.png)