### PR TITLE
Add support for showing network activity indicator on iOS in CueApi

### DIFF
--- a/Cue/app/api/CueApi.js
+++ b/Cue/app/api/CueApi.js
@@ -1,11 +1,24 @@
 // @flow
 'use strict'
 
+import { StatusBar } from 'react-native'
+
 import { serverURL } from '../env';
 
 class CueApi {
 	static userId  = null;
 	static accessToken = null;
+	static requestsPending = 0;
+
+	static setNetworkActivityIndicatorVisible(value: boolean) {
+		if (value) {
+			this.requestsPending++
+		} else {
+			this.requestsPending--
+		}
+
+		StatusBar.setNetworkActivityIndicatorVisible(this.requestsPending > 0)
+	}
 
 	static setAuthHeader(userId: ?string, accessToken: ?string) {
 		this.userId = userId;
@@ -21,6 +34,7 @@ class CueApi {
 				'X-CUE-ACCESS-TOKEN': this.accessToken,
 			}
 		}
+		this.setNetworkActivityIndicatorVisible(true)
 		return fetch(serverURL + endpoint, {
 			method: method,
 			headers: headers,
@@ -29,6 +43,7 @@ class CueApi {
 		.then(checkStatus)
 		.then(response => response.text())
 		.then(text => {
+			this.setNetworkActivityIndicatorVisible(false)
 			try {
 				return JSON.parse(text)
 			} catch (e) {
@@ -36,6 +51,7 @@ class CueApi {
 			}
 		})
 		.catch(e => {
+			this.setNetworkActivityIndicatorVisible(false)
 			throw (e)
 		});
 	}


### PR DESCRIPTION
iOS only, closes #176.

Adds support for the network activity indicator in the status bar for when there are pending `CueApi` calls. Not so useful on speedy networks, but great for if the network is struggling or if we add background sync in the future where we can't show loading indicators in the foreground.

![ezgif-3-0399feb644](https://cloud.githubusercontent.com/assets/13400887/24325761/66893010-1176-11e7-88f8-c863a2788236.gif)
