### PR TITLE
Allow for overwriting of deleted flag

### DIFF
--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -11,6 +11,7 @@ from model.card import Card
 from model.deck import Deck
 from policy.card import CardPolicy
 from policy.deck import DeckPolicy
+from model.library import Library
 from utils.base_handler import BaseHandler
 from utils.wrappers import authorize_request_and_create_db_connector, require_params, \
     extract_user_id, optional_params, optional_query_string_params
@@ -139,8 +140,8 @@ class DeckUUIDHandler(BaseHandler):
 
     @authorize_request_and_create_db_connector
     @extract_user_id
-    @require_params('name', 'public', 'tags', 'cards', 'device')
-    def post(self, name, public, tags, cards, device, user_id, connector, uuid):
+    @require_params('name', 'public', 'deleted', 'tags', 'cards', 'device')
+    def post(self, name, public, deleted, tags, cards, device, user_id, connector, uuid):
         """Overwrite an existing deck."""
 
         deck = DeckPolicy.can_edit(uuid, user_id, connector)
@@ -158,10 +159,22 @@ class DeckUUIDHandler(BaseHandler):
                 raise TypeError
             if not isinstance(tags, list):
                 raise TypeError
-
+                
             deck.set_name(name)
             deck.set_public(public)
             deck.set_tags(tags)
+
+            deck_metadata = deck.get_metadata(user_id)
+            library = Library(user_id, connector=connector)
+            
+            if deleted and not deck_metadata['deleted']: 
+                library.remove(uuid)
+                connector.end_transaction()
+                return self.make_response(response=deck.full_deck_to_json(user_id))
+
+            if not deleted and deck_metadata['deleted']:
+                deck.set_delete_flag(False)
+                library.add(uuid, device, 'private')
 
             # Determine which cards need to be deleted.
             original_cards = deck.get_cards(user_id)

--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -9,9 +9,9 @@ import logging
 from config import StatusCode
 from model.card import Card
 from model.deck import Deck
+from model.library import Library
 from policy.card import CardPolicy
 from policy.deck import DeckPolicy
-from model.library import Library
 from utils.base_handler import BaseHandler
 from utils.wrappers import authorize_request_and_create_db_connector, require_params, \
     extract_user_id, optional_params, optional_query_string_params
@@ -159,7 +159,7 @@ class DeckUUIDHandler(BaseHandler):
                 raise TypeError
             if not isinstance(tags, list):
                 raise TypeError
-                
+
             deck.set_name(name)
             deck.set_public(public)
             deck.set_tags(tags)

--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -140,8 +140,8 @@ class DeckUUIDHandler(BaseHandler):
 
     @authorize_request_and_create_db_connector
     @extract_user_id
-    @require_params('name', 'public', 'deleted', 'tags', 'cards', 'device')
-    def post(self, name, public, deleted, tags, cards, device, user_id, connector, uuid):
+    @require_params('name', 'public', 'tags', 'cards', 'device')
+    def post(self, name, public, tags, cards, device, user_id, connector, uuid):
         """Overwrite an existing deck."""
 
         deck = DeckPolicy.can_edit(uuid, user_id, connector)
@@ -166,13 +166,8 @@ class DeckUUIDHandler(BaseHandler):
 
             deck_metadata = deck.get_metadata(user_id)
             library = Library(user_id, connector=connector)
-            
-            if deleted and not deck_metadata['deleted']: 
-                library.remove(uuid)
-                connector.end_transaction()
-                return self.make_response(response=deck.full_deck_to_json(user_id))
-
-            if not deleted and deck_metadata['deleted']:
+           
+            if deck_metadata['deleted']:
                 deck.set_delete_flag(False)
                 library.add(uuid, device, 'private')
 

--- a/Server/App/model/deck.py
+++ b/Server/App/model/deck.py
@@ -52,6 +52,10 @@ class Deck(object):
         self.connector.query_transactionally(
             'UPDATE Deck SET public=%s WHERE uuid=%s', public, self.uuid)
 
+    def set_delete_flag(self, delete):
+        self.connector.query_transactionally(
+            'UPDATE Deck SET deleted=%s WHERE uuid=%s', delete, self.uuid)
+
     def nullify_share_code(self):
         self.connector.call_procedure_transactionally('SET_SHARE_CODE', self.uuid, None)
 


### PR DESCRIPTION
Closes #182 

Allows for overwriting the deletion flag of decks.

Overwriting a deleted deck:
- Sets deletion flag to false
- Adds deck back to user library
