### PR TITLE
Shorten sign out sync conflict messaging

### DIFF
--- a/Cue/app/tabs/MenuProfileItem.js
+++ b/Cue/app/tabs/MenuProfileItem.js
@@ -53,8 +53,9 @@ class MenuProfileItem extends React.Component {
             'Changes were made on this device which conflict with changes in the Cue cloud.'
               + '\n\nIf you sign out now without resolving these conflicts, you will lose all your local changes.',
             [
-              {text: "Sign Out Anyway", onPress: () => this.props.logOut(), style: 'destructive'},
-              {text: "Resolve Conflicts", onPress: () => this.props.navigator.push({failedSyncs})}
+              {text: 'Cancel', style: 'cancel'},
+              {text: 'Resolve Conflicts', onPress: () => this.props.navigator.push({failedSyncs})},
+              {text: 'Sign Out Anyway', onPress: () => this.props.logOut(), style: 'destructive'},
             ],
             { cancelable: false }
           )

--- a/Cue/app/tabs/MenuProfileItem.js
+++ b/Cue/app/tabs/MenuProfileItem.js
@@ -49,8 +49,9 @@ class MenuProfileItem extends React.Component {
       this.props.syncLibrary(this.props.localChanges).then(failedSyncs =>{
         if (failedSyncs && failedSyncs.length) {
           Alert.alert(
-            'You have local changes which conflict with changes in the Cue cloud',
-            'If you sign out now without resolving these conflicts, you will lose all your local changes',
+            'Your device is out of sync with the Cue cloud',
+            'Changes were made on this device which conflict with changes in the Cue cloud.'
+              + '\n\nIf you sign out now without resolving these conflicts, you will lose all your local changes.',
             [
               {text: "Sign Out Anyway", onPress: () => this.props.logOut(), style: 'destructive'},
               {text: "Resolve Conflicts", onPress: () => this.props.navigator.push({failedSyncs})}

--- a/Cue/app/tabs/account/AccountHome.js
+++ b/Cue/app/tabs/account/AccountHome.js
@@ -73,8 +73,9 @@ class AccountHome extends React.Component {
       this.props.syncLibrary(this.props.localChanges).then(failedSyncs =>{
         if (failedSyncs && failedSyncs.length) {
           Alert.alert(
-            'You Have Local Changes Which Conflict with Changes in the Cue Cloud',
-            'If you sign out now without resolving these conflicts, you will lose all your local changes',
+            'Your Device is Out of Sync with the Cue Cloud',
+            'Changes were made on this device which conflict with changes in the Cue cloud.'
+              + '\n\nIf you sign out now without resolving these conflicts, you will lose all your local changes.',
             [
               {text: "Sign Out Anyway", onPress: () => this.props.logOut(), style: 'destructive'},
               {text: "Resolve Conflicts", onPress: () => this.props.navigator.push({failedSyncs})}
@@ -87,7 +88,7 @@ class AccountHome extends React.Component {
       }).catch(e => {
         console.warn('Failed to sync changes', e)
         Alert.alert(
-          'Some changes haven’t been synced to the Cue cloud yet',
+          'Some Changes Haven’t Been Synced to the Cue Cloud Yet',
           'Can’t connect to the Cue cloud right now.\n\nIf you sign out now, you will lose all the changes you made while offline.',
           [
             {text: 'Sign Out Anyway', onPress: () => this.props.logOut(), style: 'destructive'},

--- a/Cue/app/tabs/account/AccountHome.js
+++ b/Cue/app/tabs/account/AccountHome.js
@@ -77,8 +77,9 @@ class AccountHome extends React.Component {
             'Changes were made on this device which conflict with changes in the Cue cloud.'
               + '\n\nIf you sign out now without resolving these conflicts, you will lose all your local changes.',
             [
-              {text: "Sign Out Anyway", onPress: () => this.props.logOut(), style: 'destructive'},
-              {text: "Resolve Conflicts", onPress: () => this.props.navigator.push({failedSyncs})}
+              {text: 'Sign Out Anyway', onPress: () => this.props.logOut(), style: 'destructive'},
+              {text: 'Resolve Conflicts', onPress: () => this.props.navigator.push({failedSyncs})},
+              {text: 'Cancel', style: 'cancel'}
             ],
             { cancelable: false }
           )


### PR DESCRIPTION
Closes #152. The title is now short enough to not be truncated on Android.

Buttons are now in sync across iOS and Android, and a Cancel option to dismiss and cancel signout has been added:
<img width="755" alt="screen shot 2017-03-26 at 3 31 41 pm" src="https://cloud.githubusercontent.com/assets/13400887/24334522/aab74f06-1239-11e7-98b4-7b15589a990b.png">
