### PR TITLE
Only call to update status bar network activity indicator if on iOS

### DIFF
--- a/Cue/app/api/CueApi.js
+++ b/Cue/app/api/CueApi.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict'
 
-import { StatusBar } from 'react-native'
+import { StatusBar, Platform } from 'react-native'
 
 import { serverURL } from '../env';
 
@@ -11,13 +11,15 @@ class CueApi {
 	static requestsPending = 0;
 
 	static setNetworkActivityIndicatorVisible(value: boolean) {
-		if (value) {
-			this.requestsPending++
-		} else {
-			this.requestsPending--
-		}
+		if (Platform.OS === 'ios') {
+			if (value) {
+				this.requestsPending++
+			} else {
+				this.requestsPending--
+			}
 
-		StatusBar.setNetworkActivityIndicatorVisible(this.requestsPending > 0)
+			StatusBar.setNetworkActivityIndicatorVisible(this.requestsPending > 0)
+		}
 	}
 
 	static setAuthHeader(userId: ?string, accessToken: ?string) {


### PR DESCRIPTION
React Native issues a warning every time you call `StatusBar.setNetworkActivityIndicatorVisible` on Android, which is endlessly annoying.

<img width="425" alt="screen shot 2017-03-26 at 6 14 52 am" src="https://cloud.githubusercontent.com/assets/13400887/24330425/8c386afe-11eb-11e7-8254-50be2ebf69ee.png">