### PR TITLE
Avoid doubling up TableRow borders on iOS

### DIFF
--- a/Cue/app/common/TableHeader.js
+++ b/Cue/app/common/TableHeader.js
@@ -1,11 +1,15 @@
 // @flow
 
 import React from 'react'
-import { View, Text, Platform } from 'react-native'
+import { View, Text, StyleSheet, Platform } from 'react-native'
 
 import CueColors from './CueColors'
 
 const iosStyles = {
+  container: {
+    borderBottomColor: CueColors.lightGrey,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
   headerText: {
     paddingHorizontal: 16,
     paddingTop: 32,
@@ -37,9 +41,11 @@ export default class TableHeader extends React.Component {
     let text = Platform.OS === 'ios' ? this.props.text.toUpperCase() : this.props.text
 
     return (
-      <Text style={styles.headerText}>
-        {text}
-      </Text>
+      <View style={styles.container || undefined}>
+        <Text style={styles.headerText}>
+          {text}
+        </Text>
+      </View>
     )
   }
 }

--- a/Cue/app/common/TableRow.js
+++ b/Cue/app/common/TableRow.js
@@ -9,10 +9,12 @@ const iosStyles = {
   row: {
     minHeight: 44,
     backgroundColor: 'white',
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: CueColors.lightGrey,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: CueColors.lightGrey,
+  },
+  rowTopBorder: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: CueColors.lightGrey,
   },
   contentContainer: {
     flexDirection: 'row',
@@ -35,6 +37,7 @@ export default class TableRow extends React.Component {
 
   props: {
     disabled?: boolean,
+    showTopBorder?: boolean,
     style?: Object,
     onPress?: () => void
   }
@@ -49,14 +52,14 @@ export default class TableRow extends React.Component {
     if (this.props.disabled) {
       return (
         <View
-          style={iosStyles.row}>
+          style={[iosStyles.row, this.props.showTopBorder ? iosStyles.rowTopBorder : undefined]}>
           {content}
         </View>
       )
     } else {
       return (
         <TouchableHighlight
-          style={iosStyles.row}
+          style={[iosStyles.row, this.props.showTopBorder ? iosStyles.rowTopBorder : undefined]}
           underlayColor={CueColors.veryLightGrey}
           onPress={this.props.onPress}>
           {content}


### PR DESCRIPTION
iOS only, closes #183.

Minor UI fix, avoids doubling up the border between adjacent `TableRow` elements on iOS by only drawing a bottom border and using `TableHeader` to draw the "top" border of the first row. Right now we don't have any groups of rows without headers, but if we ever do, there's a `showTopBorder` prop on `TableRow` which can be applied to the first row as necessary.

Does nothing on Android.

## Screenshots
Before / After
![ezgif-1-d9f3473a5a](https://cloud.githubusercontent.com/assets/13400887/24334729/d3ae095a-123d-11e7-9003-1f5fc17022ea.gif)
