### PR TITLE
Display blank view before a search is performed

### DIFF
--- a/Cue/app/tabs/search/SearchHome.js
+++ b/Cue/app/tabs/search/SearchHome.js
@@ -23,7 +23,6 @@ const styles = {
   },
   bodyContainer: {
     flex: 1,
-
   },
   searchBox: {
     color: Platform.OS === 'android' ? 'white' : CueColors.primaryText,
@@ -51,7 +50,7 @@ type Props = {
   onPressMenu?: () => void,
 
   searchString: string,
-  searchResults: Array<DeckMetadata>,
+  searchResults: ?Array<DeckMetadata>,
 
   onSearch: (searchString: string) => any,
 }
@@ -102,7 +101,7 @@ class SearchHome extends React.Component {
           <SearchListView
             style={styles.bodyContainer}
             navigator={this.props.navigator}
-            decks={this.props.searchResults || []} />
+            decks={this.props.searchResults} />
       </View>
     )
   }

--- a/Cue/app/tabs/search/SearchListView.js
+++ b/Cue/app/tabs/search/SearchListView.js
@@ -20,7 +20,7 @@ const styles = {
 
 type Props = {
   navigator: Navigator,
-  decks: Array<DeckMetadata>,
+  decks: ?Array<DeckMetadata>,
 }
 
 class SearchListView extends React.Component {
@@ -50,23 +50,26 @@ class SearchListView extends React.Component {
 
     this.state = {
       deviceOrientation: 'UNKNOWN',
-      dataSource: this.ds.cloneWithRows(props.decks)
+      dataSource: props.decks ? this.ds.cloneWithRows(props.decks) : null
     }
   }
 
-  componentWillReceiveProps(props) {
+  componentWillReceiveProps(newProps: Props) {
     this.setState({
-      ...this.state,
-      dataSource: this.ds.cloneWithRows(props.decks)
+      dataSource: newProps.decks ? this.ds.cloneWithRows(newProps.decks) : null
     })
   }
 
   render() {
+    if (!this.state.dataSource) {
+      return <View />
+    }
+
     if (this.state.dataSource.getRowCount() == 0) {
       return (
         <EmptyView
           icon={CueIcons.searchNoResults}
-          titleText={'There are no public decks matching your search'} />
+          titleText={'There are no public decks matching your search.'} />
       )
     }
     return (


### PR DESCRIPTION
Closes #106.

## Screenshots
Before a search:
<img width="757" alt="screen shot 2017-03-26 at 4 31 39 pm" src="https://cloud.githubusercontent.com/assets/13400887/24334950/1d55e81c-1242-11e7-950a-94fc73595270.png">

Search with no results:
<img width="755" alt="screen shot 2017-03-26 at 4 32 19 pm" src="https://cloud.githubusercontent.com/assets/13400887/24334956/2cae3c6a-1242-11e7-803c-482f9a212502.png">

Search with results:
<img width="755" alt="screen shot 2017-03-26 at 4 32 49 pm" src="https://cloud.githubusercontent.com/assets/13400887/24334954/28d48d06-1242-11e7-93c9-96770d75f866.png">
