### PR TITLE
Use SegmentedControlIOS on iOS for tabs instead of MaterialTabs

### DIFF
--- a/Cue/app/common/CueTabs.android.js
+++ b/Cue/app/common/CueTabs.android.js
@@ -11,6 +11,7 @@ import MaterialTabs from 'react-native-material-tabs'
 
 const styles = {
   container: {
+    marginTop: 12,
   },
 }
 
@@ -18,7 +19,7 @@ export default class CueTabs extends React.Component {
   props: {
     tabs: Array<string>,
     currentTab: string,
-    onChange: (tab) => void,
+    onChange: (tab: number) => void,
   }
 
   render() {

--- a/Cue/app/common/CueTabs.ios.js
+++ b/Cue/app/common/CueTabs.ios.js
@@ -1,0 +1,39 @@
+// @flow
+
+'use strict';
+
+import React from 'react'
+import { View, Text, SegmentedControlIOS } from 'react-native'
+
+import CueColors from './CueColors'
+
+const styles = {
+  container: {
+    marginHorizontal: 16,
+    marginVertical: 12,
+  },
+}
+
+export default class CueTabs extends React.Component {
+  props: {
+    tabs: Array<string>,
+    currentTab: string,
+    onChange: (tab: number) => void,
+  }
+
+  _onChange = ({nativeEvent: {selectedSegmentIndex}}: {nativeEvent: {selectedSegmentIndex: number}}) => {
+    this.props.onChange(selectedSegmentIndex)
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <SegmentedControlIOS
+          values={this.props.tabs}
+          selectedIndex={this.props.currentTab}
+          onChange={this._onChange}
+          tintColor={'white'} />
+      </View>
+    )
+  }
+}

--- a/Cue/app/common/DeckPreviewHeader.js
+++ b/Cue/app/common/DeckPreviewHeader.js
@@ -21,7 +21,7 @@ const styles = {
   },
   textContainer: {
     paddingHorizontal: 16,
-    paddingBottom: 16
+    paddingBottom: Platform.OS === 'android' ? 0 : 12,
   },
   deckTitle: {
     color: 'white',
@@ -66,7 +66,7 @@ export default class DeckPreviewHeader extends React.Component {
     deck: DeckMetadata,
     tabs: Array<string>,
     currentTab: number,
-    onChange: (tab) => void,
+    onChange: (tab: number) => void,
     addLibrary: () => void,
     deckInLibrary: ?Deck,
   }


### PR DESCRIPTION
Switch out `MaterialTabs` for `SegmentedControlIOS` in the deck preview header.

## Screenshots
Note the padding on Android has been adjusted slightly.

Info
![ezgif-1-f8644d188d](https://cloud.githubusercontent.com/assets/13400887/24335145/b9b321d6-1245-11e7-95c4-a4425d2d9cde.gif)

Cards
![ezgif-1-cffd61f316](https://cloud.githubusercontent.com/assets/13400887/24335147/bd943bdc-1245-11e7-9905-6e6a9b4d0640.gif)
