### PR TITLE
Pull version from build config, bump build number to 4

### DIFF
--- a/Cue/android/app/build.gradle
+++ b/Cue/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.cue"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1
+        versionCode 4
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/Cue/app/common/CueAppInfo.js
+++ b/Cue/app/common/CueAppInfo.js
@@ -1,0 +1,13 @@
+// @flow
+
+import DeviceInfo from 'react-native-device-info'
+
+function getVersionString() {
+  return `${DeviceInfo.getVersion()} (${DeviceInfo.getBuildNumber()})`
+}
+
+function getCreditsLine() {
+  return `Cue ${getVersionString()} by Project Orange`
+}
+
+module.exports = { getVersionString, getCreditsLine }

--- a/Cue/app/tabs/CueTabsView.android.js
+++ b/Cue/app/tabs/CueTabsView.android.js
@@ -81,8 +81,7 @@ class CueTabsView extends React.Component {
         />
         <ListViewHairlineSeparator
           style={styles.separator} />
-        <MenuCreditsItem
-          version={'0.1'} />
+        <MenuCreditsItem />
       </View>
     );
   }

--- a/Cue/app/tabs/MenuCreditsItem.js
+++ b/Cue/app/tabs/MenuCreditsItem.js
@@ -3,6 +3,8 @@
 import React from 'react'
 import { View, Text } from 'react-native'
 
+import { getCreditsLine } from '../common/CueAppInfo'
+
 import CueColors from '../common/CueColors'
 
 const styles = {
@@ -16,15 +18,11 @@ const styles = {
 }
 
 export default class MenuCreditsItem extends React.Component {
-  props: {
-    version: string
-  }
-
   render() {
     return (
       <View style={styles.container}>
         <Text style={styles.text}>
-          Cue {this.props.version} by Project Orange
+          {getCreditsLine()}
         </Text>
       </View>
     )

--- a/Cue/app/tabs/account/AccountHome.js
+++ b/Cue/app/tabs/account/AccountHome.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { View, Text, TouchableHighlight, Alert, Navigator } from 'react-native'
+import { View, Text, StyleSheet, TouchableHighlight, Alert, Navigator } from 'react-native'
 
 import { connect } from 'react-redux'
 import { logOut } from '../../actions/login'
@@ -33,15 +33,12 @@ const styles = {
     padding: 48,
     textAlign: 'center',
   },
-  signOutButtonContainer: {
-    flexDirection: 'row'
-  },
   signOutButton: {
-    flex: 1,
-    borderTopColor: CueColors.veryLightGrey,
-    borderTopWidth: 1,
-    borderBottomColor: CueColors.veryLightGrey,
-    borderBottomWidth: 1,
+    width: '100%',
+    borderTopColor: CueColors.lightGrey,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: CueColors.lightGrey,
+    borderBottomWidth: StyleSheet.hairlineWidth,
     paddingVertical: 12,
     paddingHorizontal: 16,
   },
@@ -117,16 +114,14 @@ class AccountHome extends React.Component {
             <Text style={styles.headerText}>
               {this.props.user.name || 'Cue'}
             </Text>
-            <View style={styles.signOutButtonContainer}>
-              <TouchableHighlight
-                style={styles.signOutButton}
-                underlayColor={CueColors.veryLightGrey}
-                onPress={this._logOut}>
-                <Text style={styles.signOutButtonText}>
-                  Sign Out
-                </Text>
-              </TouchableHighlight>
-            </View>
+            <TouchableHighlight
+              style={styles.signOutButton}
+              underlayColor={CueColors.veryLightGrey}
+              onPress={this._logOut}>
+              <Text style={styles.signOutButtonText}>
+                Sign Out
+              </Text>
+            </TouchableHighlight>
           </View>
           <View style={styles.creditsContainer}>
             <Text style={styles.creditsText}>

--- a/Cue/app/tabs/account/AccountHome.js
+++ b/Cue/app/tabs/account/AccountHome.js
@@ -7,6 +7,8 @@ import { connect } from 'react-redux'
 import { logOut } from '../../actions/login'
 import { syncLibrary } from '../../actions/library'
 
+import { getCreditsLine } from '../../common/CueAppInfo'
+
 import CueColors from '../../common/CueColors'
 import CueHeader from '../../common/CueHeader'
 import CueIcons from '../../common/CueIcons'
@@ -128,7 +130,7 @@ class AccountHome extends React.Component {
           </View>
           <View style={styles.creditsContainer}>
             <Text style={styles.creditsText}>
-              Cue 0.1 by Project Orange
+              {getCreditsLine()}
             </Text>
           </View>
         </View>

--- a/Cue/ios/Cue/Info.plist
+++ b/Cue/ios/Cue/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>4</string>
 	<key>FacebookAppID</key>
 	<string>764348623743727</string>
 	<key>FacebookDisplayName</key>


### PR DESCRIPTION
<sup>High-key I'm really upset that I didn't find out about JS backtick string templates until now.</sup>

Closes #195.

## Summary
This pull request:

1. Updates `AccountHome` and `MenuCreditsItem` to pull the version info from the build configuration
2. Bumps the build number to 4 since the current build number on TestFlight is 3.

## Caveats
Unfortunately we have to update the build number for both iOS (in `Info.plist`) and Android (in `settings.gradle`) manually, but *c'est la vie* unless we actually create some centralized build system, which.. ain't nobody got time fo' that.

## Screenshots
<img width="755" alt="screen shot 2017-03-26 at 6 20 29 pm" src="https://cloud.githubusercontent.com/assets/13400887/24335747/5be2e9ea-1251-11e7-9b14-743fe2cb003a.png">
