### PR TITLE
Fix loading spinner alignment on login screen

### DIFF
--- a/Cue/app/login/LoginScreen.js
+++ b/Cue/app/login/LoginScreen.js
@@ -93,7 +93,7 @@ class LoginScreen extends React.Component {
       </View>
     );
 
-    let spinner = <ActivityIndicator color={'white'} />;
+    let spinner = <ActivityIndicator style={styles.loginContent} color={'white'} />;
 
     let content = this.state.loading ? loginContent : spinner;
 


### PR DESCRIPTION
Closes #197.

Oops, fixed the alignment. Before screenshot is in the linked issue.

<img width="755" alt="screen shot 2017-03-26 at 8 25 56 pm" src="https://cloud.githubusercontent.com/assets/13400887/24336779/9c278bee-1262-11e7-8dea-7ad981a05b9f.png">
