### PR TITLE
Expose HTTP status code in error messages

### DIFF
--- a/Cue/app/api/CueApi.js
+++ b/Cue/app/api/CueApi.js
@@ -54,7 +54,10 @@ class CueApi {
 		})
 		.catch(e => {
 			this.setNetworkActivityIndicatorVisible(false)
-			throw (e)
+			if (!e.recoveryMessage) {
+				e.recoveryMessage = 'Check your Internet connection and try again.'
+			}
+			throw e
 		});
 	}
 }
@@ -64,8 +67,9 @@ var checkStatus = function(response) {
 		return response;
 	} else {
 		console.warn('Cue API request returned bad status code', response)
-		let error = new Error(response);
+		let error = new Error(response.status);
 		error.response = response;
+		error.recoveryMessage = `An error occurred (${response.status}). Try again in a few moments.`
 		throw error;
 	}
 }

--- a/Cue/app/tabs/MenuProfileItem.js
+++ b/Cue/app/tabs/MenuProfileItem.js
@@ -64,9 +64,15 @@ class MenuProfileItem extends React.Component {
         }
       }).catch(e => {
         console.warn('Failed to sync changes', e)
+
+        let message = (e.response && e.response.status
+              ? `Can’t sync with the Cue cloud right now (${e.response.status}).`
+              : 'Can’t connect to the Cue cloud right now.')
+          + '\n\nIf you sign out now, you will lose all the changes you made while offline.'
+
         Alert.alert(
           'Some changes haven’t been synced to the Cue cloud yet',
-          'Can’t connect to the Cue cloud right now.\n\nIf you sign out now, you will lose all the changes you made while offline.',
+          message,
           [{text: 'Sign Out Anyway', onPress: () => this.props.logOut(), style: 'destructive'},
            {text: 'Cancel', style: 'cancel'}],
            { cancelable: false }

--- a/Cue/app/tabs/account/AccountHome.js
+++ b/Cue/app/tabs/account/AccountHome.js
@@ -87,9 +87,15 @@ class AccountHome extends React.Component {
         }
       }).catch(e => {
         console.warn('Failed to sync changes', e)
+
+        let message = (e.response && e.response.status
+              ? `Can’t sync with the Cue cloud right now (${e.response.status}).`
+              : 'Can’t connect to the Cue cloud right now.')
+          + '\n\nIf you sign out now, you will lose all the changes you made while offline.'
+
         Alert.alert(
           'Some Changes Haven’t Been Synced to the Cue Cloud Yet',
-          'Can’t connect to the Cue cloud right now.\n\nIf you sign out now, you will lose all the changes you made while offline.',
+          message,
           [
             {text: 'Sign Out Anyway', onPress: () => this.props.logOut(), style: 'destructive'},
             {text: 'Cancel', style: 'cancel'}

--- a/Cue/app/tabs/discover/DiscoverHome.js
+++ b/Cue/app/tabs/discover/DiscoverHome.js
@@ -67,9 +67,10 @@ class DiscoverHome extends React.Component {
       this.setState({
         refreshing: false,
       });
+
       Alert.alert(
         (Platform.OS === 'android' ? 'Failed to fetch Discovery decks' : 'Failed to Fetch Discovery Decks'),
-        'Check your Internet connection and try again.'
+        e.recoveryMessage
       )
     })
   }

--- a/Cue/app/tabs/library/DeckSharingOptions.js
+++ b/Cue/app/tabs/library/DeckSharingOptions.js
@@ -169,12 +169,12 @@ class DeckSharingOptions extends React.Component {
         })
         .catch(e => {
           console.warn('Failed to generate share code', e)
+
           Alert.alert(
             (Platform.OS === 'android'
               ? 'Could not generate share code'
               : 'Could Not Generate Share Code'),
-            'Check your Internet connection and try again.',
-            [{text: 'OK', style: 'cancel'}]
+            e.recoveryMessage
           )
         })
     } else {

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -117,9 +117,10 @@ class LibraryHome extends React.Component {
       .catch(e => {
         this.setState({refreshing: false})
         console.warn('Failed to sync changes', e)
+        
         Alert.alert(
           (Platform.OS === 'android' ? 'Cue cloud sync failed' : 'Cue Cloud Sync Failed'),
-          'Check your Internet connection and try again.'
+          e.recoveryMessage
         )
       })
     }

--- a/Cue/app/tabs/search/SearchHome.js
+++ b/Cue/app/tabs/search/SearchHome.js
@@ -62,9 +62,10 @@ class SearchHome extends React.Component {
     this.props.onSearch(searchText)
     .catch(e => {
       console.warn('Failed to search for decks', e)
+      
       Alert.alert(
         (Platform.OS === 'android' ? 'Failed to search for decks' : 'Failed to Search for Decks'),
-        'Check your Internet connection and try again.'
+        e.recoveryMessage
       )
     })
   }


### PR DESCRIPTION
Closes #206.

In cases where we have connectivity but receive an error response from the server, we should expose the status code and stop telling people to check their Internet connection.

This also makes it easier to diagnose issues when the app is built in release mode and doesn't expose any React UI for looking deeper into errors.

<img width="487" alt="screen shot 2017-03-27 at 3 33 49 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374973/b9fb78c2-1304-11e7-8bcf-7313da265a86.png">
<img width="487" alt="screen shot 2017-03-27 at 3 33 57 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374975/ba0167a0-1304-11e7-8187-1c2a0f6be36a.png">
<img width="487" alt="screen shot 2017-03-27 at 3 34 08 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374976/ba020408-1304-11e7-95ee-5323ffd95c84.png">
<img width="487" alt="screen shot 2017-03-27 at 3 34 16 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374978/ba027aa0-1304-11e7-94ef-32da76fef824.png">
<img width="487" alt="screen shot 2017-03-27 at 3 35 36 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374977/ba02449a-1304-11e7-91d8-fcf5c7df609c.png">
<img width="571" alt="screen shot 2017-03-27 at 3 35 55 pm" src="https://cloud.githubusercontent.com/assets/13400887/24374979/ba02fcdc-1304-11e7-8f0f-cb10d0482ea2.png">
