### PR TITLE
Avoid calling API twice for simple deck creates

### DIFF
--- a/Cue/app/api/Library.js
+++ b/Cue/app/api/Library.js
@@ -32,7 +32,7 @@ var LibraryApi = {
       device: DeviceInfo.getDeviceName(),
       cards: cards,
     })
-		console.info('Creating deck "' + name + '" at endpoint ' + endpoint)
+		console.info(`Creating deck "${name}" with body ${body} at endpoint: ${endpoint}`)
     return CueApi.fetch(endpoint, 'POST', body)
   },
 
@@ -56,7 +56,7 @@ var LibraryApi = {
       actions
     })
 
-    console.info('editing deck' + body + ' at endpoint ' + endpoint)
+    console.info(`Editing deck ${body} at endpoint: ${endpoint}`)
     return CueApi.fetch(endpoint, 'PUT', body)
   },
 


### PR DESCRIPTION
Closes #208.

The Create Deck API handles deck name, tags, and list of cards. Don't call the Edit Deck API during deck create unless necessary.

Private deck before:
<img width="1051" alt="screen shot 2017-03-27 at 3 59 03 pm" src="https://cloud.githubusercontent.com/assets/13400887/24376025/781abab8-1308-11e7-90d4-4d2037121061.png">

Private deck after:
<img width="1051" alt="screen shot 2017-03-27 at 4 05 08 pm" src="https://cloud.githubusercontent.com/assets/13400887/24376040/83d8e528-1308-11e7-9f79-92a2eb8c5b36.png">

Public deck still calls edit deck API:
<img width="1051" alt="screen shot 2017-03-27 at 4 14 17 pm" src="https://cloud.githubusercontent.com/assets/13400887/24376039/83d89e92-1308-11e7-8c44-848a2809a092.png">