### PR TITLE
Use utf8mb4 and migrate db to utf8mb4

### DIFF
--- a/Server/App/api/deck.py
+++ b/Server/App/api/deck.py
@@ -166,7 +166,7 @@ class DeckUUIDHandler(BaseHandler):
 
             deck_metadata = deck.get_metadata(user_id)
             library = Library(user_id, connector=connector)
-           
+
             if deck_metadata['deleted']:
                 deck.set_delete_flag(False)
                 library.add(uuid, device, 'private')

--- a/Server/App/config.py
+++ b/Server/App/config.py
@@ -24,7 +24,7 @@ class DBConfig(object):
     PASSWORD = os.getenv('DB_PASSWORD', 'root')
     HOST = os.getenv('DB_HOST', 'localhost')
     DB_NAME = 'Cue'
-    CHARSET = 'utf8'
+    CHARSET = 'utf8mb4'
     SCHEMA_PATH = 'SQL/schema.sql'
     PROCEDURE_PATH = 'SQL/procedures.sql'
     TESTDATA_DIRECTORY = 'SQL/Testdata'

--- a/Server/SQL/Migrations/2017-03-27_15-30.sql
+++ b/Server/SQL/Migrations/2017-03-27_15-30.sql
@@ -1,0 +1,46 @@
+USE Cue;
+START TRANSACTION;
+-- BEGIN MIGRATION --
+
+SET foreign_key_checks = 0;
+
+ALTER DATABASE Cue CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+ALTER TABLE User CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Deck CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Card CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Library CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE NeedReview CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Rating CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE User CHANGE uuid uuid VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE User CHANGE fb_user_id fb_user_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE User CHANGE access_token access_token VARCHAR(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE User CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE Deck CHANGE uuid uuid VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Deck CHANGE name name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Deck CHANGE owner owner VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Deck CHANGE tags_delimited tags_delimited VARCHAR(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Deck CHANGE share_code share_code VARCHAR(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE Card CHANGE uuid uuid VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Card CHANGE deck_id deck_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Card CHANGE front front VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Card CHANGE back back VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE Library CHANGE user_id user_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Library CHANGE deck_id deck_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Library CHANGE last_update_device last_update_device VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Library CHANGE accession accession VARCHAR(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE NeedReview CHANGE card_id card_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE NeedReview CHANGE user_id user_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE Rating CHANGE user_id user_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE Rating CHANGE deck_id deck_id VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+SET foreign_key_checks = 1;
+
+-- END MIGRATION --
+COMMIT;


### PR DESCRIPTION
- Have to turn off foreign key checks during migration while you switch character set
- This means that we have the same amount of bytes available in these columns but potentially less characters since certain unicode characters can take up to 4 bytes

Closes #204