### PR TITLE
Automatically trigger sync

### DIFF
--- a/Cue/android/app/src/main/AndroidManifest.xml
+++ b/Cue/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 
     <uses-sdk

--- a/Cue/app/common/CueColors.js
+++ b/Cue/app/common/CueColors.js
@@ -12,7 +12,7 @@ module.exports = {
   primaryTintDarker: '#193C70', // or Material Blue 900 '#0D47A1'?
 
   dangerTint: '#FF3B30',
-  warningTint: '#F39019',
+  warningTint: '#FF9500',
 
   primaryText: '#53585F',
   lightText: 'rgba(0, 0, 0, 0.4)',

--- a/Cue/app/common/CueColors.js
+++ b/Cue/app/common/CueColors.js
@@ -12,6 +12,7 @@ module.exports = {
   primaryTintDarker: '#193C70', // or Material Blue 900 '#0D47A1'?
 
   dangerTint: '#FF3B30',
+  warningTint: '#F39019',
 
   primaryText: '#53585F',
   lightText: 'rgba(0, 0, 0, 0.4)',

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -114,8 +114,8 @@ class LibraryHome extends React.Component {
         console.info('Triggering sync due to network status change')
         this._refresh()
       } else {
-        console.info(`Not triggering sync (isConnected: ${isConnected}, `
-          + `shouldThrottle: ${shouldThrottle}, msSinceLastSync: ${msSinceLastSync})`)
+        console.info(`Not triggering sync (isConnected: ${isConnected.toString()}, `
+          + `shouldThrottle: ${shouldThrottle.toString()}, msSinceLastSync: ${msSinceLastSync.toString()})`)
       }
     }
   }

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -200,7 +200,6 @@ class LibraryHome extends React.Component {
       if (shouldSync) {
         console.info('_onNetworkIsConnectedChanged: Requesting sync due to network status change')
 
-        // The top-level route is just {}
         if (this._isLibraryHomeInForeground()) {
           console.info('_onNetworkIsConnectedChanged: '
             + 'LibraryHome is in the foreground; refreshing now')

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -246,7 +246,7 @@ class LibraryHome extends React.Component {
           this.setState({refreshing: false, lastSyncTime: new Date(), needsSync: false})
           this.props.navigator.push({failedSyncs})
         } else {
-          this.props.onLoadLibrary().then(response => {
+          return this.props.onLoadLibrary().then(response => {
             this.setState({refreshing: false, lastSyncTime: new Date(), needsSync: false})
           })
         }

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -150,7 +150,7 @@ class LibraryHome extends React.Component {
   }
 
   componentWillUnmount() {
-    NetInfo.isConnected.addEventListener('change', this._onNetworkIsConnectedChanged)
+    NetInfo.isConnected.removeEventListener('change', this._onNetworkIsConnectedChanged)
   }
 
   _refresh = () => {


### PR DESCRIPTION
# Please test this on a physical Android device.
My emulator seems to really like [ignoring our error handlers](https://cloud.githubusercontent.com/assets/13400887/24382531/d0f89d5a-1324-11e7-9505-6afbad26467e.png), so I'd like to test this on a Real Android Device™.

Note that the network reachability check on Android is much more naïve than the check on iOS, in that it only checks if you have either an active cell data or WiFi connection, rather than actually testing if the network is usable. If you're testing this in an emulator, you'll need to "disconnect" the device by going into the emulator settings and setting `Cellular > Data status` to `Unregistered (off)`.

## Summary
Closes #28 **but not #205**. This pull request:
1. Adds support for triggering sync based on network availability.
2. Adds a new "Offline Mode" banner under the header in `LibraryHome` to indicate when a device has no network connectivity.
3. Adds support for triggering sync based on whether there are local changes when the Navigator pops to `LibraryHome`.

## Important Caveats
* **In this implementation, `LibraryHome` owns the listener for network availability changes and owns automatically triggering sync.**
    * This works fine on iOS since the component doesn't unmount when switching to a different tab.
    * On Android, even though the component unmounts when the tab is switched, I'm inclined to say that this is OK since in most use cases, `LibraryHome` will be mounted.
    * This does make the component kind of large though.

## Implementation Details
* `LibraryHome` has gained three new pieces of state:
    1. `connected: ?boolean` - whether the network is available
    2. `lastSyncTime: ?Date` - the last time a call to the API succeeded
    3. `needsSync: boolean` - set if a sync is triggered but `LibraryHome` is not in the foreground
* `LibraryHome` has gained two new listeners, each responsible for listening to different state changes:
    1. `_onNavigatorEvent` listens for Navigator events. When `LibraryHome` enters the foreground, checks if `needsSync` is set or if `localChanges` is non-empty. If yes and the network is available, then a sync is triggered.
    2. `_onNetworkIsConnectedChanged` listens for network connectivity changes. If the network becomes available and `LibraryHome` is in the foreground, then a sync is triggered. Otherwise if `LibraryHome` is in the background, then `needsSync` is set to true.

## Screenshots
Offline mode banner:
<img width="755" alt="screen shot 2017-03-27 at 7 56 40 pm" src="https://cloud.githubusercontent.com/assets/13400887/24382941/a9e1f6dc-1327-11e7-9813-a00725d97ebf.png">

Message when the banner is tapped:
<img width="755" alt="screen shot 2017-03-27 at 7 56 58 pm" src="https://cloud.githubusercontent.com/assets/13400887/24382942/a9eb61fe-1327-11e7-8d59-985011743e34.png">

Note that the list scrolls *under* the banner:
<img width="755" alt="screen shot 2017-03-27 at 7 58 43 pm" src="https://cloud.githubusercontent.com/assets/13400887/24382983/e959e536-1327-11e7-89b0-67a2aa15f1d1.png">