### PR TITLE
Don't display placeholder on iOS in CuePrompt

### DIFF
--- a/Cue/app/common/CuePrompt.js
+++ b/Cue/app/common/CuePrompt.js
@@ -28,7 +28,6 @@ const CuePrompt = {
         message,
         buttons,
         'plain-text',
-        placeholder
       )
     }
   }

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -178,7 +178,7 @@ class LibraryHome extends React.Component {
     const MAX_LENGTH = 255
     CuePrompt.prompt(
       Platform.OS === 'android' ? 'Create new deck' : 'Create New Deck',
-      'Enter a name for your new deck.',
+      'Enter a name for your deck.',
       [
         {text: 'Cancel', style: 'cancel'},
         {text: 'Create', onPress: (deckName) => {

--- a/Cue/app/tabs/library/LibraryHome.js
+++ b/Cue/app/tabs/library/LibraryHome.js
@@ -117,7 +117,7 @@ class LibraryHome extends React.Component {
       .catch(e => {
         this.setState({refreshing: false})
         console.warn('Failed to sync changes', e)
-        
+
         Alert.alert(
           (Platform.OS === 'android' ? 'Cue cloud sync failed' : 'Cue Cloud Sync Failed'),
           e.recoveryMessage
@@ -178,7 +178,7 @@ class LibraryHome extends React.Component {
     const MAX_LENGTH = 255
     CuePrompt.prompt(
       Platform.OS === 'android' ? 'Create new deck' : 'Create New Deck',
-      '',
+      'Enter a name for your new deck.',
       [
         {text: 'Cancel', style: 'cancel'},
         {text: 'Create', onPress: (deckName) => {


### PR DESCRIPTION
Closes #212.

Since the placeholder is actually filled in as the default value by `AlertIOS.prompt`, don't display placeholders on iOS to avoid forcing the users to clear the text box before allowing them to enter what they want.

<img width="755" alt="screen shot 2017-03-27 at 9 22 46 pm" src="https://cloud.githubusercontent.com/assets/13400887/24384740/197cb110-1334-11e7-8969-b65b1d455c52.png">
