### PR TITLE
Change naming of copied deck

### DIFF
--- a/Cue/app/actions/library.js
+++ b/Cue/app/actions/library.js
@@ -177,7 +177,7 @@ function copyDeck(localDeck: Deck) : Action {
   })
 
   let deck = {
-    name: localDeck.name,
+    name: 'Copy of ' + localDeck.name,
     uuid: uuidV4(),
     public: false,
     cards: newCards,


### PR DESCRIPTION
Closes #215 

As you would expect:
![deckcopy](https://cloud.githubusercontent.com/assets/6856391/24385834/575715b0-133a-11e7-90af-4e88e9828c8e.png)
