### PR TITLE
Add iPad support

### DIFF
--- a/Cue/ios/Cue.xcodeproj/project.pbxproj
+++ b/Cue/ios/Cue.xcodeproj/project.pbxproj
@@ -1169,6 +1169,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = Cue;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1187,6 +1188,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = Cue;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/Cue/ios/Cue/Info.plist
+++ b/Cue/ios/Cue/Info.plist
@@ -69,6 +69,13 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
Careful, it's a *big* one.

## Summary
This pull request:
1. Adds support for iPad. 😉 

## Notes
All jokes aside, this is actually to prevent #201 from occurring when our app runs on iPad. Previously, our app was built for iPhone only, so when it ran on the iPad, it would run with a viewport size equivalent to the iPhone 4s, leading to a really cramped layout.

Compare before:
![img_0342](https://cloud.githubusercontent.com/assets/13400887/24390622/1f02cac4-1358-11e7-879d-6f58baed515b.PNG)
![img_0343](https://cloud.githubusercontent.com/assets/13400887/24390621/1ef2fed2-1358-11e7-963a-a3bcc69f60da.PNG)
![img_0344](https://cloud.githubusercontent.com/assets/13400887/24390620/1ee490ae-1358-11e7-8417-2f212ded89ca.PNG)

with after:
![img_0345](https://cloud.githubusercontent.com/assets/13400887/24390637/2a25eaa8-1358-11e7-8a3e-e0dea77216d4.PNG)
![img_0346](https://cloud.githubusercontent.com/assets/13400887/24390638/2a264548-1358-11e7-85a4-f5a1a9275cc8.PNG)
![img_0347](https://cloud.githubusercontent.com/assets/13400887/24390639/2a27168a-1358-11e7-83ef-e7b6a65dcc03.PNG)

So we go from cramped and buggy to just sort of goofy-looking. I'd consider that a positive change.
