### PR TITLE
Allow number of columns in LibraryListView to vary

### DIFF
--- a/Cue/app/common/DeckThumbnail.js
+++ b/Cue/app/common/DeckThumbnail.js
@@ -88,13 +88,32 @@ export default class DeckThumbnail extends React.Component {
     onPressDelete?: () => void,
   }
 
+  _getWidth = () => {
+    const paddingOneSide = 16
+    const minWidth = 160
+    const windowWidth = Dimensions.get('window').width
+
+    // With n columns, we have n + 1 instances of 16 pt horizontal margins,
+    // so subtract one extra 16 pt from the window width to get the number
+    // of columns we can hold given the window width.
+    const effectiveWindowWidth = windowWidth - paddingOneSide
+
+    // However, we should always show at least 2 columns, even if it falls
+    // below the minimm width.
+    let numColumns = Math.max(
+      2,
+      Math.floor(effectiveWindowWidth / (minWidth + paddingOneSide)))
+
+    return Math.floor(effectiveWindowWidth / numColumns) - paddingOneSide
+  }
+
   render() {
     // Add the width style prop based on the current window dimens
     let styles = {
       ...baseStyles,
       itemContainer: {
         ...baseStyles.itemContainer,
-        width: Math.floor((Dimensions.get('window').width - 48) / 2),
+        width: this._getWidth(),
       }
     }
 

--- a/Cue/app/tabs/discover/DiscoverHome.js
+++ b/Cue/app/tabs/discover/DiscoverHome.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { View, Text, Image, ScrollView, ListView, RefreshControl, Navigator, Platform, Alert } from 'react-native'
+import { View, Text, Image, ScrollView, ListView, RefreshControl, Navigator, Platform, Dimensions, Alert } from 'react-native'
 import type { DeckMetadata } from '../../api/types';
 
 import { discoverDecks } from '../../actions'
@@ -40,7 +40,8 @@ class DiscoverHome extends React.Component {
 
   state: {
     dataSource: ListView.DataSource,
-    refreshing: boolean
+    refreshing: boolean,
+    deviceOrientation: 'LANDSCAPE' | 'PORTRAIT' | 'UNKNOWN',
   }
 
   ds: ListView.DataSource
@@ -53,11 +54,21 @@ class DiscoverHome extends React.Component {
       sectionHeaderHasChanged: (s1, s2) => s1 !== s2
     })
 
-    this.state = this._getNewState(props)
+    this.state = {
+      ...this._getNewState(props),
+      deviceOrientation: 'UNKNOWN',
+    }
   }
 
   componentWillReceiveProps(newProps) {
     this.setState(this._getNewState(newProps))
+  }
+
+  _onLayout = () => {
+    let { width, height } = Dimensions.get('window')
+    this.setState({
+      deviceOrientation: width > height ? 'LANDSCAPE' : 'PORTRAIT',
+    })
   }
 
   _fetchDiscoverDecks = () => {
@@ -124,6 +135,8 @@ class DiscoverHome extends React.Component {
           leftItem={menuItem}
           title='Discover' />
         <ListView
+          key={this.state.deviceOrientation}
+          onLayout={this._onLayout}
           automaticallyAdjustContentInsets={false}
           contentInset={{bottom: 49}}
           style={styles.bodyContainer}

--- a/Cue/app/tabs/library/LibraryListView.js
+++ b/Cue/app/tabs/library/LibraryListView.js
@@ -16,11 +16,11 @@ import DeckThumbnail from '../../common/DeckThumbnail'
 
 const styles = {
   list: {
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     flexDirection: 'row',
     flexWrap: 'wrap',
     alignItems: 'flex-start',
-    paddingHorizontal: 16,
+    paddingLeft: 16,
 
     // FAB height (56) + FAB padding (16) - to avoid crashing into FAB
     paddingBottom: Platform.OS === 'android' ? 72 : undefined,
@@ -48,7 +48,7 @@ class LibraryListView extends React.Component {
 
   state: {
     dataSource: ListView.DataSource,
-    deviceOrientation: string
+    deviceOrientation: 'LANDSCAPE' | 'PORTRAIT' | 'UNKNOWN',
   }
 
   _onLayout = () => {
@@ -121,6 +121,7 @@ class LibraryListView extends React.Component {
         <DeckThumbnail
           deck={deck}
           deletable={this.props.editing}
+          style={{marginRight: 16}}
           onPress={() => this.props.navigator.push({deck: deck})}
           onPressDelete={() => this.props.onDeleteDeck(deck)}/>
       </View>

--- a/Cue/app/tabs/library/LibraryListView.js
+++ b/Cue/app/tabs/library/LibraryListView.js
@@ -27,6 +27,7 @@ const styles = {
   },
   cardContainer: {
     marginBottom: 16,
+    marginRight: 16,
   }
 }
 
@@ -121,7 +122,6 @@ class LibraryListView extends React.Component {
         <DeckThumbnail
           deck={deck}
           deletable={this.props.editing}
-          style={{marginRight: 16}}
           onPress={() => this.props.navigator.push({deck: deck})}
           onPressDelete={() => this.props.onDeleteDeck(deck)}/>
       </View>

--- a/Cue/app/tabs/search/SearchListView.js
+++ b/Cue/app/tabs/search/SearchListView.js
@@ -30,7 +30,7 @@ class SearchListView extends React.Component {
 
   state: {
     dataSource: ListView.DataSource,
-    deviceOrientation: string
+    deviceOrientation: 'LANDSCAPE' | 'PORTRAIT' | 'UNKNOWN',
   }
 
   _onLayout = () => {
@@ -74,7 +74,10 @@ class SearchListView extends React.Component {
     }
     return (
       <ListView
+        key={this.state.deviceOrientation}
         onLayout={this._onLayout}
+        automaticallyAdjustContentInsets={false}
+        contentInset={{bottom: 49}}
         contentContainerStyle={styles.list}
         dataSource={this.state.dataSource}
         renderRow={deck => <SearchListViewItem navigator={this.props.navigator} deck={deck} />}


### PR DESCRIPTION
Closes #220. 

## Summary
This pull request:
1. Allows the number of columns in `LibraryListView` to vary by dynamically calculating the width of `DeckThumbnail` based on the current window width
2. Forces the list to re-render on orientation change in `LibraryListView`, `DiscoverHome`, and `SearchListView` to allow `DeckThumbnail` to re-render using the updated window width

Building on #219 which added iPad support, this makes `LibraryListView` more comfortable to use in landscape and on larger tablet-sized devices.

## Screenshots
Portrait still looks like it used to:
<img width="755" alt="screen shot 2017-03-28 at 2 31 51 am" src="https://cloud.githubusercontent.com/assets/13400887/24391758/e0523c68-135e-11e7-9cb9-b0b2280a88a7.png">

Landscape now has 3 columns instead of 2:
<img width="672" alt="screen shot 2017-03-28 at 2 32 25 am" src="https://cloud.githubusercontent.com/assets/13400887/24391772/e830e862-135e-11e7-8897-e735e5fe949c.png">

iPad now looks great in both orientations:
![img_0349](https://cloud.githubusercontent.com/assets/13400887/24391785/ffe310e8-135e-11e7-8f17-4c26a8bac1ba.PNG)
![img_0350](https://cloud.githubusercontent.com/assets/13400887/24391786/fff3fe26-135e-11e7-8d44-a1d75c52fce4.PNG)

Also works on Nexus 10 (don't ask me why the shadows from the `elevation` are like that, I have no idea):
<img width="1295" alt="screen shot 2017-03-28 at 2 51 44 am" src="https://cloud.githubusercontent.com/assets/13400887/24392359/9103ab62-1361-11e7-81c6-553adb117635.png">