### PR TITLE
Relax restrictions on characters allowed in tags

### DIFF
--- a/Cue/app/tabs/library/DeckSharingOptions.js
+++ b/Cue/app/tabs/library/DeckSharingOptions.js
@@ -5,6 +5,7 @@
 import React from 'react'
 import { View, Text, Navigator, Platform, Alert } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview'
+import { remove as stripDiacritics } from 'diacritics'
 
 import type { Deck } from '../../api/types'
 
@@ -287,14 +288,18 @@ class DeckSharingOptions extends React.Component {
   /* ==================== Tags ==================== */
 
   _onTagAdded = (tag: string) => {
-    if (!this.state.tags.includes(tag)) {
+    // We store tags with diacritics and everything, but we disallow storing
+    // multiple tags which are the same when diacritics are stripped.
+    let canonicalizedTag = stripDiacritics(tag)
+    let tagExists = this.state.tags.some((value: string) => stripDiacritics(value) === canonicalizedTag)
+
+    if (!tagExists) {
       if (this.state.tags.concat([tag]).join(',').length > MAX_TAGS_LENGTH) {
         Alert.alert(
           (Platform.OS === 'android'
             ? 'Tags limit exceeded'
             : 'Tags Limit Exceeded'),
           'The combined length of all the tags must be less than 500 characters.',
-          [{text: 'OK', style: 'cancel'}]
         )
       } else {
         this.setState({

--- a/Cue/app/tabs/library/TagsTableRow.js
+++ b/Cue/app/tabs/library/TagsTableRow.js
@@ -4,7 +4,6 @@
 
 import React from 'react'
 import { View, Text, TextInput, Platform } from 'react-native'
-import { remove as stripDiacritics } from 'diacritics'
 
 import Chip from '../../common/Chip'
 import CueColors from '../../common/CueColors'
@@ -48,10 +47,9 @@ export default class TagsTableRow extends React.Component {
   _onEndEditing = ({nativeEvent: {text}}) => {
     this.textInputRef.clear()
 
-    let tag = stripDiacritics(text)
+    let tag = text
       .trim()
       .toLowerCase()
-      .replace(new RegExp('[^-a-z0-9 ]', 'g'), '')
       .replace(new RegExp(' +', 'g'), ' ')
 
     if (tag.length > 0) {

--- a/Cue/app/tabs/library/TagsTableRow.js
+++ b/Cue/app/tabs/library/TagsTableRow.js
@@ -4,6 +4,7 @@
 
 import React from 'react'
 import { View, Text, TextInput, Platform } from 'react-native'
+import { remove as stripDiacritics } from 'diacritics'
 
 import Chip from '../../common/Chip'
 import CueColors from '../../common/CueColors'
@@ -47,8 +48,10 @@ export default class TagsTableRow extends React.Component {
   _onEndEditing = ({nativeEvent: {text}}) => {
     this.textInputRef.clear()
 
-    let tag = text.trim().toLowerCase()
-      .replace(new RegExp('[^-a-z ]', 'g'), '')
+    let tag = stripDiacritics(text)
+      .trim()
+      .toLowerCase()
+      .replace(new RegExp('[^-a-z0-9 ]', 'g'), '')
       .replace(new RegExp(' +', 'g'), ' ')
 
     if (tag.length > 0) {

--- a/Cue/package.json
+++ b/Cue/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dateformat": "^2.0.0",
+    "diacritics": "^1.3.0",
     "react": "15.4.2",
     "react-native": "^0.42.0",
     "react-native-button": "^1.8.2",


### PR DESCRIPTION
Closes #222.

## Summary
This pull request:
1. Relaxes the restrictions on tags to allow any character
2. Disallows storing tags which compare equal when diacritics are stripped.

----
# Previously:

## Summary
This pull request:
1. Allows numbers in tags
2. Strips diacritics before filtering out non-alphanumeric characters in tags

@ClaytonPassmore @henryc132 Does have some unforeseen negative effect on full-text search on the server?

![ezgif-1-fe10f53248](https://cloud.githubusercontent.com/assets/13400887/24393925/0556e672-1368-11e7-916e-9cb435374e54.gif)
