### PR TITLE
Turn on "Flagged cards only" if deck view was filtering

### DIFF
--- a/Cue/app/tabs/library/DeckView.js
+++ b/Cue/app/tabs/library/DeckView.js
@@ -167,7 +167,7 @@ class DeckView extends React.Component {
         [{text: 'OK', style: 'cancel'}]
       )
     } else {
-      this.props.navigator.push({ playDeckSetup: this.state.deck, flagFilter: this.state.isFiltering })
+      this.props.navigator.push({ playDeckSetup: this.state.deck, flagFilter: this.state.filtering })
     }
   }
 


### PR DESCRIPTION
We originally had this behavior but somewhere along the line it broke (maybe it was me? IDK works now :stuck_out_tongue_closed_eyes: )