### PR TITLE
(Mostly) properly centre indicators when swiping in Play Mode

### DIFF
--- a/Cue/app/tabs/library/play/PlayDeckView.js
+++ b/Cue/app/tabs/library/play/PlayDeckView.js
@@ -211,18 +211,20 @@ class PlayDeckView extends React.Component {
       case 'flag':
         toValue = {
           x: 0,
-          y: -1 * windowLayout.height
+          // Approximately adjust to keep the flag somewhat centred when released
+          y: -1.25 * (windowLayout.height - 68),
         }
         break
       case 'next':
         toValue = {
-          x: -1 * windowLayout.width,
+          // Account for 0.4:1 damping + width + 1.5x padding of indicator
+          x: -1.25 * (windowLayout.width - 68),
           y: 0
         }
         break
       case 'back':
         toValue = {
-          x: windowLayout.width,
+          x: 1.25 * (windowLayout.width - 68),
           y: 0
         }
         break


### PR DESCRIPTION
Previously the calculation for how far off the screen to move the card didn't account for the 0.4:1 damping, width, and horizontal padding of the indicators, so on wider viewports, the icons would be visibly misaligned when the card was released.