### PR TITLE
Fix crash in LibraryListView when sorting

### DIFF
--- a/Cue/android/app/build.gradle
+++ b/Cue/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "club.projectorange.Cue"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 8
+        versionCode 9
         versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/Cue/app/tabs/library/LibraryListView.js
+++ b/Cue/app/tabs/library/LibraryListView.js
@@ -62,8 +62,8 @@ class LibraryListView extends React.Component {
 
   _categorizeDecks(decks: Array<Deck>) {
     decks = decks.slice().sort((a: Deck, b: Deck) => {
-      let left = a.name.toUpperCase()
-      let right = b.name.toUpperCase()
+      let left = (a.name || '').toUpperCase()
+      let right = (b.name || '').toUpperCase()
 
       if (left < right) return -1
       if (left > right) return 1

--- a/Cue/ios/Cue/Info.plist
+++ b/Cue/ios/Cue/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>FacebookAppID</key>
 	<string>764348623743727</string>
 	<key>FacebookDisplayName</key>


### PR DESCRIPTION
In some cases, an empty object can be inserted into the `library` sub-store. To prevent crashing in `LibraryListView`, guard against `undefined` values for `name` when sorting.