### PR TITLE
Adjust CardEntryView height when keyboard is visible

### DIFF
--- a/Cue/app/common/TextEntryTableRow.js
+++ b/Cue/app/common/TextEntryTableRow.js
@@ -40,6 +40,8 @@ export default class TextEntryTableRow extends React.Component {
     focused: boolean,
   }
 
+  textInputRef: ?TextInput
+
   constructor(props: Props) {
     super(props)
 
@@ -48,6 +50,14 @@ export default class TextEntryTableRow extends React.Component {
       height: 0,
       focused: false,
     }
+  }
+
+  getTextInputRef = (): ?TextInput => {
+    return this.textInputRef
+  }
+
+  _onTextInputRef = (textInputRef: TextInput) => {
+    this.textInputRef = textInputRef
   }
 
   // We need both onChange and onContentSizeChange for height since:
@@ -105,6 +115,7 @@ export default class TextEntryTableRow extends React.Component {
       <TableRow style={tableRowExtraStyle}>
         <TextInput
           style={[styles.textInput, {height: this.state.height}]}
+          ref={this._onTextInputRef}
           multiline
           onChange={this._onChange}
           onContentSizeChange={this._onContentSizeChange}

--- a/Cue/app/tabs/library/CardEntryView.js
+++ b/Cue/app/tabs/library/CardEntryView.js
@@ -3,7 +3,8 @@
 'use strict'
 
 import React from 'react'
-import { View, ScrollView, Text, Navigator, Platform } from 'react-native'
+import { View, Text, Navigator, Platform } from 'react-native'
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scrollview'
 
 import type { Card } from '../../api/types'
 
@@ -41,6 +42,9 @@ export default class CardEntryView extends React.Component {
     backText: string
   }
 
+  frontRowRef: ?TextEntryTableRow
+  backRowRef: ?TextEntryTableRow
+
   constructor(props: Props) {
     super(props)
 
@@ -55,6 +59,14 @@ export default class CardEntryView extends React.Component {
       && this.state.frontText.length <= MAX_LENGTH
       && this.state.backText.length > 0
       && this.state.backText.length <= MAX_LENGTH
+  }
+
+  _onFrontRowRef = (ref: TextEntryTableRow) => {
+    this.frontRowRef = ref
+  }
+
+  _onBackRowRef = (ref: TextEntryTableRow) => {
+    this.backRowRef = ref
   }
 
   _onFrontTextChange = (text: string) => {
@@ -117,10 +129,14 @@ export default class CardEntryView extends React.Component {
           leftItem={leftItem}
           rightItems={rightItems} />
 
-        <ScrollView style={{flex: 1}}>
+        <KeyboardAwareScrollView
+          style={{flex: 1}}
+          getTextInputRefs={() => [this.frontRowRef ? this.frontRowRef.getTextInputRef() : undefined,
+                                   this.backRowRef ? this.backRowRef.getTextInputRef() : undefined]}>
           <TableHeader
             text={'Card front'} />
           <TextEntryTableRow
+            ref={this._onFrontRowRef}
             initialText={this.props.existingCard ? this.props.existingCard.front : undefined}
             placeholder={'Card front text'}
             maxLength={MAX_LENGTH}
@@ -132,6 +148,7 @@ export default class CardEntryView extends React.Component {
           <TableHeader
             text={'Card back'} />
           <TextEntryTableRow
+            ref={this._onBackRowRef}
             initialText={this.props.existingCard ? this.props.existingCard.back : undefined}
             placeholder={'Card back text'}
             maxLength={MAX_LENGTH}
@@ -139,7 +156,7 @@ export default class CardEntryView extends React.Component {
           <TableFooter
             style={styles.characterCounter}
             text={this._getCharactersRemainingString(this.state.backText)} />
-        </ScrollView>
+        </KeyboardAwareScrollView>
       </View>
     )
   }


### PR DESCRIPTION
## Summary

Closes #238. This pull request:

1. Swaps `ScrollView` for `KeyboardAwareScrollView` which will account for the height of the keyboard when scrolling.

## Screenshots

Observe that the bottom text input is not obscured by the keyboard:
<img width="504" alt="screen shot 2017-11-19 at 3 33 08 pm" src="https://user-images.githubusercontent.com/13400887/32996990-063a29be-cd3f-11e7-8851-d079a037dadf.png">
